### PR TITLE
enable ROS web_video_server node, add python2 matplotlib package

### DIFF
--- a/bundle/deepracer_simulation_environment/share/deepracer_simulation_environment/launch/racetrack_with_racecar.launch
+++ b/bundle/deepracer_simulation_environment/share/deepracer_simulation_environment/launch/racetrack_with_racecar.launch
@@ -73,4 +73,7 @@
   <node pkg="deepracer_simulation_environment" type="save_to_mp4.py" name="save_to_mp4" args="racecar" output="screen" required="true" unless="$(arg multicar)"></node>
   <node pkg="deepracer_simulation_environment" type="save_to_mp4.py" name="save_to_mp4" args="racecar_0,racecar_1" required="true" output="screen" if="$(arg multicar)"></node>
 
+  <!-- Enable local web server for video streaming -->
+  <node name="web_video_server" pkg="web_video_server" type="web_video_server" output="screen" required="false"></node>
+
 </launch>

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -56,7 +56,7 @@ RUN python2 -m pip install --no-cache-dir opencv-python 'numpy==1.11'
 COPY bundle /opt/install
 WORKDIR /opt/install
 RUN apt-get update -y && rosdep install --from-paths deepracer_simulation_environment --ignore-src -r -y && \
-    apt-get install -y ros-kinetic-media-export && \
+    apt-get install -y ros-kinetic-media-export ros-kinetic-web-video-server python-matplotlib && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 ENV COLCON_CURRENT_PREFIX="/opt/install"
@@ -69,5 +69,6 @@ RUN patch -p1 -N --directory=/usr/local/lib/python3.5/dist-packages/ < /opt/amaz
 COPY ./docker/files/run.sh run.sh
 
 RUN rm -f /opt/ros/kinetic/lib/python2.7/dist-packages/cv2.so
+
 ENTRYPOINT ["/bin/bash", "-c"]
 CMD ["./run.sh run distributed_training.launch"]


### PR DESCRIPTION
Adds ros-kinetic-web-video-server package and also adds a node to racetrack_with_racecar.launch to launch the web server.

Video streams can be viewed by pointing a web browser at port 8080 of the running robomaker container.
