### PR TITLE
Add connect and read timeouts to get_boto_config()

### DIFF
--- a/bundle/sagemaker_rl_agent/lib/python3.5/site-packages/markov/utils.py
+++ b/bundle/sagemaker_rl_agent/lib/python3.5/site-packages/markov/utils.py
@@ -41,6 +41,9 @@ CHKPNT_KEY_SUFFIX = "model/.coach_checkpoint"
 DEEPRACER_CHKPNT_KEY_SUFFIX = "model/deepracer_checkpoints.json"
 # The number of times to retry a failed boto call
 NUM_RETRIES = 5
+# Timeouts (in seconds) for boto calls (improves performance when simulating S3 using minio)
+CONNECT_TIMEOUT = 3
+READ_TIMEOUT = 3 # Need to verify in future that small values here doesn't cause problems with large 5-layer CNNs
 
 class Logger(object):
     counter = 0
@@ -70,7 +73,7 @@ def force_list(val):
 
 def get_boto_config():
     '''Returns a botocore config object which specifies the number of times to retry'''
-    return botocore.config.Config(retries=dict(max_attempts=NUM_RETRIES))
+    return botocore.config.Config(retries=dict(max_attempts=NUM_RETRIES), connect_timeout=CONNECT_TIMEOUT, read_timeout=READ_TIMEOUT)
 
 def cancel_simulation_job(simulation_job_arn, aws_region):
     logger.info("cancel_simulation_job: make sure to shutdown simapp first")


### PR DESCRIPTION
When training locally with minio sometimes it can take 30-60 seconds to upload checkpoints due to some sort of minio or docker networking weirdness.
