### PR TITLE
Keep physics paused if not worker index 0

### DIFF
--- a/bundle/sagemaker_rl_agent/lib/python3.5/site-packages/markov/rollout_worker.py
+++ b/bundle/sagemaker_rl_agent/lib/python3.5/site-packages/markov/rollout_worker.py
@@ -174,11 +174,11 @@ def rollout_worker(graph_manager, num_workers, rollout_idx, task_parameters, s3_
             new_checkpoint = -1
             if graph_manager.agent_params.algorithm.distributed_coach_synchronization_type\
                     == DistributedCoachSynchronizationType.SYNC:
-                unpause_physics(EmptyRequest())
                 is_save_mp4_enabled = rospy.get_param('MP4_S3_BUCKET', None) and rollout_idx == 0
                 if is_save_mp4_enabled:
                     subscribe_to_save_mp4(EmptyRequest())
                 if rollout_idx == 0:
+                    unpause_physics(EmptyRequest())
                     for _ in range(MIN_EVAL_TRIALS):
                         graph_manager.evaluate(EnvironmentSteps(1))
 


### PR DESCRIPTION
Pausing physics if not the evaluation worker reduces CPU load during policy training and evaluation when having more than one robomaker worker at once.