### PR TITLE
Update wrong mesh names for New_York_Track

### DIFF
--- a/bundle/deepracer_simulation_environment/share/deepracer_simulation_environment/models/New_York_Track/New_York_Track_model.sdf
+++ b/bundle/deepracer_simulation_environment/share/deepracer_simulation_environment/models/New_York_Track/New_York_Track_model.sdf
@@ -78,7 +78,7 @@
 <pose>0 0 0 0 0 0</pose>
 <geometry>
 <mesh>
-<uri>model://meshes/New_York_Track/New_York_track_building_wall</uri>
+<uri>model://meshes/New_York_Track/New_York_track_building_wall.dae</uri>
 </mesh>
 </geometry>
 </collision>
@@ -86,7 +86,7 @@
 <pose>0 0 0 0 0 0</pose>
 <geometry>
 <mesh>
-<uri>model://meshes/New_York_Track/New_York_track_building_wall</uri>
+<uri>model://meshes/New_York_Track/New_York_track_building_wall.dae</uri>
 </mesh>
 </geometry>
 </visual>
@@ -332,7 +332,7 @@
 <pose>0 0 0 0 0 0</pose>
 <geometry>
 <mesh>
-<uri>model://meshes/New_York_Track/New_York_track_road_light.dae</uri>
+<uri>model://meshes/New_York_Track/New_york_track_road_light.dae</uri>
 </mesh>
 </geometry>
 </collision>
@@ -340,7 +340,7 @@
 <pose>0 0 0 0 0 0</pose>
 <geometry>
 <mesh>
-<uri>model://meshes/New_York_Track/New_York_track_road_light.dae</uri>
+<uri>model://meshes/New_York_Track/New_york_track_road_light.dae</uri>
 </mesh>
 </geometry>
 </visual>


### PR DESCRIPTION
Currently, when using the New York Track as the DR_WORLD_NAME, Robomaker process would fail. Updating the incorrect mesh names to its correct one seems to fix the issue.