### PR TITLE
Node Monitor + Kill container on complete

### DIFF
--- a/bundle/markov/utils.py
+++ b/bundle/markov/utils.py
@@ -2,6 +2,7 @@ import threading
 import json
 import logging
 import os
+import subprocess
 import io
 import re
 import signal
@@ -74,8 +75,10 @@ def cancel_simulation_job():
         robomaker_client.cancel_simulation_job(job=simulation_job_arn)
         logger.info("Successfully cancelled the simulation job")
     else:
-        logger.info("AWS_ROBOMAKER_SIMULATION_JOB_ARN environment variable not set. Failed cancellation.")
- 
+        logger.info("AWS_ROBOMAKER_SIMULATION_JOB_ARN environment variable not set - assume local docker container")
+        subprocess.run(["/opt/install/shutdown.sh"])
+        logger.info("Shutdown initiated")
+        exit(0)
 
 def str2bool(flag):
     """ bool: convert flag to boolean if it is string and return it else return its initial bool value """

--- a/bundle/src/deepracer_simulation_environment/launch/racetrack_with_racecar.launch
+++ b/bundle/src/deepracer_simulation_environment/launch/racetrack_with_racecar.launch
@@ -84,6 +84,6 @@
   </node>
 
   <!-- Enable local web server for video streaming -->
-  <node name="web_video_server" pkg="web_video_server" type="web_video_server" output="screen" required="false"></node>
+  <node pkg="web_video_server" type="web_video_server" name="web_video_server" output="screen" required="false" respawn="false"></node>
 
 </launch>

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -121,6 +121,9 @@ COPY ./bundle/rl_coach.patch /opt/rl_coach.patch
 RUN patch -p1 -N --directory=/usr/local/lib/python3.6/dist-packages/ < /opt/rl_coach.patch
 COPY ./docker/files/run.sh run.sh
 COPY ./docker/files/debug-reward.diff debug-reward.diff
+COPY ./docker/files/shutdown.sh shutdown.sh
+COPY ./bundle/script/start_deepracer_node_monitor.py start_deepracer_node_monitor.py
+COPY ./bundle/src/deepracer_node_monitor/config/deepracer_evaluation_node_monitor_list.txt deepracer_evaluation_node_monitor_list.txt
 
 COPY VERSION .
 ARG IMG_VERSION

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -121,6 +121,9 @@ COPY ./bundle/rl_coach.patch /opt/rl_coach.patch
 RUN patch -p1 -N --directory=/usr/local/lib/python3.6/dist-packages/ < /opt/rl_coach.patch
 COPY ./docker/files/run.sh run.sh
 COPY ./docker/files/debug-reward.diff debug-reward.diff
+COPY ./docker/files/shutdown.sh shutdown.sh
+COPY ./bundle/script/start_deepracer_node_monitor.py start_deepracer_node_monitor.py
+COPY ./bundle/src/deepracer_node_monitor/config/deepracer_evaluation_node_monitor_list.txt deepracer_evaluation_node_monitor_list.txt
 
 COPY VERSION .
 ARG IMG_VERSION

--- a/docker/files/run.sh
+++ b/docker/files/run.sh
@@ -105,4 +105,7 @@ else
 fi
 
 echo "IP: $(hostname -I) ($(hostname))"
+
+python3 start_deepracer_node_monitor.py --node_monitor_file_path=deepracer_evaluation_node_monitor_list.txt
+
 wait

--- a/docker/files/shutdown.sh
+++ b/docker/files/shutdown.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+nohup bash -c 'sleep 20 && echo "Bye!" && kill 1' &


### PR DESCRIPTION
Two features:
* Start node monitor - would enable publishing of status to S3
* Kill container if main thread exits