### PR TITLE
Cap the number of steps per iteration

### DIFF
--- a/bundle/markov/deepracer_memory.py
+++ b/bundle/markov/deepracer_memory.py
@@ -1,4 +1,5 @@
 from threading import Thread, Event, Lock
+import os
 import pickle
 import queue
 import logging
@@ -194,9 +195,15 @@ class DeepRacerTrainerBackEnd(MemoryBackend):
         # Pubsub object that will allow us to subscribe to the data channel and request data
         self.data_pubsubs = dict()
         self.request_events = dict()
-        self.max_step = MAX_MEMORY_STEPS_SHALLOW \
-            if self.params.network_type == NeuralNetwork.DEEP_CONVOLUTIONAL_NETWORK_SHALLOW.value \
-            else MAX_MEMORY_STEPS
+
+        max_steps = os.environ.get("MAX_MEMORY_STEPS", "")
+        if max_steps.isdigit() and (int(max_steps) > 0):
+            self.max_step = int(max_steps)
+            LOG.info("Capping iteration steps at: %i", int(max_steps))
+        else:
+            self.max_step = MAX_MEMORY_STEPS_SHALLOW \
+                if self.params.network_type == NeuralNetwork.DEEP_CONVOLUTIONAL_NETWORK_SHALLOW.value \
+                else MAX_MEMORY_STEPS
 
         for agent_param in agents_params:
             self.rollout_steps[agent_param.name] = 0

--- a/bundle/markov/training_worker.py
+++ b/bundle/markov/training_worker.py
@@ -228,6 +228,10 @@ def main():
                         help='(string) AWS region',
                         type=str,
                         default=os.environ.get("AWS_REGION", "us-east-1"))
+    parser.add_argument('--max_memory_steps',
+                        help='(int) Max steps per iteration',
+                        type=int,
+                        default=0)
     parser.add_argument('--cuda_visible_devices',
                         help='(string) Cuda Visible Devices',
                         type=str,
@@ -236,6 +240,10 @@ def main():
     args, _ = parser.parse_known_args()
     logger.info("Training Worker Args: %s" % args)
     logger.info("S3 bucket: %s \n S3 prefix: %s \n S3 endpoint URL: %s", args.s3_bucket, args.s3_prefix, args.s3_endpoint_url)
+
+    if args.max_memory_steps > 0:
+        logger.info("Setting max memory steps to %i" % args.max_memory_steps)
+        os.environ['MAX_MEMORY_STEPS'] = str(args.max_memory_steps)
 
     if args.cuda_visible_devices is not None:
         logger.info("Setting CUDA visible device to {}".format(args.cuda_visible_devices))


### PR DESCRIPTION
Default is 10.000, now it can be tuned lower for less VRAM usage and increased for more VRAM usage.

Changed code is not used in Robomaker, but the coach loads this into Sagemaker!