### PR TITLE
Add KVS extra overlay, laptime best model metric. 

### DIFF
--- a/bundle/markov/metrics/constants.py
+++ b/bundle/markov/metrics/constants.py
@@ -108,7 +108,9 @@ class Mp4VideoMetrics(Enum):
     CRASH_COUNTER = 'crash_counter'
     THROTTLE = 'throttle'
     STEERING = 'steering'
+    SPEED = 'speed'
     BEST_LAP_TIME = 'best_lap_time'
+    LAST_LAP_TIME = 'last_lap_time'
     TOTAL_EVALUATION_TIME = 'total_evaluation_time'
     DONE = 'done'
     X = 'x'
@@ -132,3 +134,4 @@ class BestModelMetricType(Enum):
     """This enum is used to determine the metric to use when selecting best model"""
     PROGRESS = 'progress'
     REWARD = 'reward'
+    LAPTIME = 'laptime'

--- a/bundle/markov/metrics/s3_metrics.py
+++ b/bundle/markov/metrics/s3_metrics.py
@@ -181,7 +181,6 @@ class TrainingMetrics(MetricsInterface, ObserverInterface, AbstractTracker):
             if self._best_model_metric_type == BestModelMetricType.REWARD:
                 self._current_eval_best_model_metric_list_.append(self._episode_reward_)
             elif self._best_model_metric_type == BestModelMetricType.LAPTIME:
-                print(f"DEBUG: Best model metric is laptime")
                 if self._progress_ >= 100:
                     self._current_eval_best_model_metric_list_.append(int(round((self._current_sim_time - self._start_time_) * 1000)))
                 else:
@@ -204,7 +203,6 @@ class TrainingMetrics(MetricsInterface, ObserverInterface, AbstractTracker):
     def update(self, data):
         self._is_eval_ = data != RunPhase.TRAIN
 
-        print(f"DEBUG: is_eval: {self._is_eval_}, use_model_picker: {self._use_model_picker}")
         if not self._is_eval_ and self._use_model_picker:
             if self._eval_stats_dict_['chkpnt_name'] is None:
                 self._eval_stats_dict_['chkpnt_name'] = self._checkpoint_state_.read().name

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/multi_agent_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/multi_agent_image_editing.py
@@ -107,7 +107,7 @@ class MultiAgentImageEditing(ImageEditingInterface):
                                                            font_color=RaceCarColorToRGB.White.value,
                                                            font_shadow_color=RaceCarColorToRGB.Black.value)
                 
-                if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower in ('true'):
+                if rospy.get_param('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower in ('true'):
                     # Steering Angle
                     loc_y += 25
                     steering_text = "Steering | {}".format(mp4_video_metrics_info[i].steering)

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/multi_agent_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/multi_agent_image_editing.py
@@ -106,7 +106,8 @@ class MultiAgentImageEditing(ImageEditingInterface):
                                                            loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
                                                            font_color=RaceCarColorToRGB.White.value,
                                                            font_shadow_color=RaceCarColorToRGB.Black.value)
-                if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', False):
+                
+                if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower in ('true'):
                     # Steering Angle
                     loc_y += 25
                     steering_text = "Steering | {}".format(mp4_video_metrics_info[i].steering)

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/multi_agent_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/multi_agent_image_editing.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import rospy
 import cv2
+import os
 
 from markov.log_handler.logger import Logger
 from markov.reset.constants import RaceType
@@ -105,8 +106,25 @@ class MultiAgentImageEditing(ImageEditingInterface):
                                                            loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
                                                            font_color=RaceCarColorToRGB.White.value,
                                                            font_shadow_color=RaceCarColorToRGB.Black.value)
+                if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', False):
+                    # Steering Angle
+                    loc_y += 25
+                    steering_text = "Steering | {}".format(mp4_video_metrics_info[i].steering)
+                    major_cv_image = utils.write_text_on_image(image=major_cv_image, text=steering_text,
+                                                            loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
+                                                            font_color=RaceCarColorToRGB.White.value,
+                                                            font_shadow_color=RaceCarColorToRGB.Black.value)
+                    
+                    # Throttle
+                    loc_y += 25
+                    steering_text = "Throttle | {}".format(mp4_video_metrics_info[i].throttle)
+                    major_cv_image = utils.write_text_on_image(image=major_cv_image, text=steering_text,
+                                                            loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
+                                                            font_color=RaceCarColorToRGB.White.value,
+                                                            font_shadow_color=RaceCarColorToRGB.Black.value)
+                
                 if self.racecar_name == racecar_info['name']:
-                    agents_speed = mp4_video_metrics_info[i].throttle
+                    agents_speed = mp4_video_metrics_info[i].speed
                 # The race is complete when total lap is same as current lap and done flag is set
                 agent_done = agent_done or (mp4_video_metrics_info[i].done and (current_lap == int(self._total_laps)))
 

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/multi_agent_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/multi_agent_image_editing.py
@@ -107,7 +107,7 @@ class MultiAgentImageEditing(ImageEditingInterface):
                                                            font_color=RaceCarColorToRGB.White.value,
                                                            font_shadow_color=RaceCarColorToRGB.Black.value)
                 
-                if rospy.get_param('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower in ('true'):
+                if rospy.get_param('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower() in ('true'):
                     # Steering Angle
                     loc_y += 25
                     steering_text = "Steering | {}".format(mp4_video_metrics_info[i].steering)

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/single_agent_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/single_agent_image_editing.py
@@ -104,7 +104,7 @@ class SingleAgentImageEditing(ImageEditingInterface):
                                                    loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
                                                    font_color=RaceCarColorToRGB.White.value,
                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
-        if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower in ('true'):
+        if rospy.get_param('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower() in ('true'):
             loc_y += 25
             best_lap_time = mp4_video_metrics_info[self.racecar_index].best_lap_time
             # The initial default best_lap_time from s3_metrics.py is inf

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/single_agent_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/single_agent_image_editing.py
@@ -104,7 +104,7 @@ class SingleAgentImageEditing(ImageEditingInterface):
                                                    loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
                                                    font_color=RaceCarColorToRGB.White.value,
                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
-        if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', False):
+        if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower in ('true'):
             loc_y += 25
             best_lap_time = mp4_video_metrics_info[self.racecar_index].best_lap_time
             # The initial default best_lap_time from s3_metrics.py is inf

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/single_agent_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/single_agent_image_editing.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import rospy
 import cv2
+import os
 
 from markov.log_handler.logger import Logger
 from markov.utils import get_racecar_idx
@@ -103,6 +104,21 @@ class SingleAgentImageEditing(ImageEditingInterface):
                                                    loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
                                                    font_color=RaceCarColorToRGB.White.value,
                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
+        if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', False):
+            loc_y += 25
+            best_lap_time = mp4_video_metrics_info[self.racecar_index].best_lap_time
+            # The initial default best_lap_time from s3_metrics.py is inf
+            # If the ros service in s3_metrics.py has not come up yet, best_lap_time is 0
+            best_lap_time = utils.milliseconds_to_timeformat(
+                datetime.timedelta(milliseconds=best_lap_time)) \
+                if best_lap_time != float("inf") and best_lap_time != 0 else "--:--.---"
+                
+            best_lap_time_text = "Best lap | {}".format(best_lap_time) 
+            major_cv_image = utils.write_text_on_image(image=major_cv_image, text=best_lap_time_text,
+                                                    loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
+                                                    font_color=RaceCarColorToRGB.White.value,
+                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
+        
         # Reset counter
         loc_y += 25
         reset_counter_text = "Reset | {}".format(mp4_video_metrics_info[self.racecar_index].reset_counter)
@@ -110,11 +126,28 @@ class SingleAgentImageEditing(ImageEditingInterface):
                                                    loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
                                                    font_color=RaceCarColorToRGB.White.value,
                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
+        
+        # Steering Angle
+        loc_y += 25
+        steering_text = "Steering | {}".format(mp4_video_metrics_info[self.racecar_index].steering)
+        major_cv_image = utils.write_text_on_image(image=major_cv_image, text=steering_text,
+                                                   loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
+                                                   font_color=RaceCarColorToRGB.White.value,
+                                                   font_shadow_color=RaceCarColorToRGB.Black.value)
+        
+        # Throttle
+        loc_y += 25
+        steering_text = "Throttle | {}".format(mp4_video_metrics_info[self.racecar_index].throttle)
+        major_cv_image = utils.write_text_on_image(image=major_cv_image, text=steering_text,
+                                                   loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
+                                                   font_color=RaceCarColorToRGB.White.value,
+                                                   font_shadow_color=RaceCarColorToRGB.Black.value)
+        
         # Speed
         loc_x, loc_y = XYPixelLoc.SPEED_EVAL_LOC.value
         if self.is_league_leaderboard:
             loc_x, loc_y = XYPixelLoc.SPEED_LEADERBOARD_LOC.value
-        speed_text = "{} m/s".format(utils.get_speed_formatted_str(mp4_video_metrics_info[self.racecar_index].throttle))
+        speed_text = "{} m/s".format(utils.get_speed_formatted_str(mp4_video_metrics_info[self.racecar_index].speed))
         major_cv_image = utils.write_text_on_image(image=major_cv_image, text=speed_text,
                                                    loc=(loc_x, loc_y), font=self.amazon_ember_light_20px,
                                                    font_color=RaceCarColorToRGB.White.value,

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/training_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/training_image_editing.py
@@ -62,7 +62,7 @@ class TrainingImageEditing(ImageEditingInterface):
         major_cv_image = utils.apply_gradient(major_cv_image, self.gradient_alpha_rgb_mul,
                                               self.one_minus_gradient_alpha)
         
-        if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', False):
+        if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower in ('true'):
             width, height = IconographicImageSize.FULL_IMAGE_SIZE.value
             major_cv_image = utils.plot_rectangle(major_cv_image, 0, 0, width, 85, RaceCarColorToRGB.Black.value )
             

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/training_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/training_image_editing.py
@@ -5,6 +5,7 @@ import logging
 import cv2
 import datetime
 import os
+import rospy
 import numpy as np
 
 from markov.log_handler.logger import Logger
@@ -62,7 +63,7 @@ class TrainingImageEditing(ImageEditingInterface):
         major_cv_image = utils.apply_gradient(major_cv_image, self.gradient_alpha_rgb_mul,
                                               self.one_minus_gradient_alpha)
         
-        if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower in ('true'):
+        if rospy.get_param('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower in ('true'):
             width, height = IconographicImageSize.FULL_IMAGE_SIZE.value
             major_cv_image = utils.plot_rectangle(major_cv_image, 0, 0, width, 85, RaceCarColorToRGB.Black.value )
             

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/training_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/training_image_editing.py
@@ -3,6 +3,8 @@ This module takes care of addressing each race type editting of images.
 """
 import logging
 import cv2
+import datetime
+import os
 import numpy as np
 
 from markov.log_handler.logger import Logger
@@ -28,6 +30,7 @@ class TrainingImageEditing(ImageEditingInterface):
         self.racecar_index = racecar_index if racecar_index else 0
         # Store the font which we will use to write the phase with
         self.training_phase_font = utils.get_font('Amazon_Ember_RgIt', 35)
+        self.amazon_ember_light_18px = utils.get_font('AmazonEmber-Light', 18)
 
         # The track image as iconography
         self.track_icongraphy_img = utils.get_track_iconography_image()
@@ -48,7 +51,7 @@ class TrainingImageEditing(ImageEditingInterface):
                                                  top_camera_info.image_width, top_camera_info.image_height,
                                                  racecar_info)
 
-    def _edit_major_cv_image(self, major_cv_image, cur_training_phase):
+    def _edit_major_cv_image(self, major_cv_image, cur_training_phase, mp4_video_metrics_info):
         """ Apply all the editing for the Major 45degree camera image
         Args:
             major_cv_image (Image): Image straight from the camera
@@ -58,6 +61,69 @@ class TrainingImageEditing(ImageEditingInterface):
         # Applying gradient to whole major image and then writing text
         major_cv_image = utils.apply_gradient(major_cv_image, self.gradient_alpha_rgb_mul,
                                               self.one_minus_gradient_alpha)
+        
+        if os.environ.get('ENABLE_EXTRA_KVS_OVERLAY', False):
+            width, height = IconographicImageSize.FULL_IMAGE_SIZE.value
+            major_cv_image = utils.plot_rectangle(major_cv_image, 0, 0, width, 85, RaceCarColorToRGB.Black.value )
+            
+            # Top left location of the picture
+            loc_x, loc_y = XYPixelLoc.SINGLE_AGENT_DISPLAY_NAME_LOC.value
+            
+            # Best lap time
+            best_lap_time = mp4_video_metrics_info[self.racecar_index].best_lap_time
+            # The initial default best_lap_time from s3_metrics.py is inf
+            # If the ros service in s3_metrics.py has not come up yet, best_lap_time is 0
+            best_lap_time = utils.milliseconds_to_timeformat(
+                datetime.timedelta(milliseconds=best_lap_time)) \
+                if best_lap_time != float("inf") and best_lap_time != 0 else "--:--.---"    
+            best_lap_time_text = "Best lap | {}".format(best_lap_time) 
+            major_cv_image = utils.write_text_on_image(image=major_cv_image, text=best_lap_time_text,
+                                                    loc=(width-180, loc_y), font=self.amazon_ember_light_18px,
+                                                    font_color=RaceCarColorToRGB.White.value,
+                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
+            
+            # Last lap time
+            last_lap_time = mp4_video_metrics_info[self.racecar_index].last_lap_time
+            # The initial default last_lap_time from s3_metrics.py is inf
+            # If the ros service in s3_metrics.py has not come up yet, last_lap_time is 0
+            last_lap_time = utils.milliseconds_to_timeformat(
+                datetime.timedelta(milliseconds=last_lap_time)) \
+                if last_lap_time != float("inf") and last_lap_time != 0 else "--:--.---"    
+            last_lap_time_text = "Last lap | {}".format(last_lap_time) 
+            major_cv_image = utils.write_text_on_image(image=major_cv_image, text=last_lap_time_text,
+                                                    loc=(width-180, loc_y+25), font=self.amazon_ember_light_18px,
+                                                    font_color=RaceCarColorToRGB.White.value,
+                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
+            
+            # Progress
+            progress_text = "Progress | {}".format(round(mp4_video_metrics_info[self.racecar_index].completion_percentage,2)) 
+            major_cv_image = utils.write_text_on_image(image=major_cv_image, text=progress_text,
+                                                    loc=(width-180, loc_y+50), font=self.amazon_ember_light_18px,
+                                                    font_color=RaceCarColorToRGB.White.value,
+                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
+            
+            # Steering Angle
+            steering_text = "Steering | {}".format(mp4_video_metrics_info[self.racecar_index].steering)
+            major_cv_image = utils.write_text_on_image(image=major_cv_image, text=steering_text,
+                                                    loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
+                                                    font_color=RaceCarColorToRGB.White.value,
+                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
+            
+            # Throttle
+            loc_y += 25
+            steering_text = "Throttle | {}".format(round(mp4_video_metrics_info[self.racecar_index].throttle,3))
+            major_cv_image = utils.write_text_on_image(image=major_cv_image, text=steering_text,
+                                                    loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
+                                                    font_color=RaceCarColorToRGB.White.value,
+                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
+            
+            # Speed
+            loc_y += 25
+            speed_text = "Speed | {} m/s".format(utils.get_speed_formatted_str(mp4_video_metrics_info[self.racecar_index].speed))
+            major_cv_image = utils.write_text_on_image(image=major_cv_image, text=speed_text,
+                                                    loc=(loc_x, loc_y), font=self.amazon_ember_light_18px,
+                                                    font_color=RaceCarColorToRGB.White.value,
+                                                    font_shadow_color=RaceCarColorToRGB.Black.value)
 
         # Add the label that lets the user know the training phase
         major_cv_image = utils.write_text_on_image(image=major_cv_image, text=cur_training_phase,
@@ -116,6 +182,6 @@ class TrainingImageEditing(ImageEditingInterface):
         mp4_video_metrics_info = metric_info[FrameQueueData.AGENT_METRIC_INFO.value]
         cur_training_phase = metric_info[FrameQueueData.TRAINING_PHASE.value]
 
-        major_cv_image = self._edit_major_cv_image(major_cv_image, cur_training_phase)
+        major_cv_image = self._edit_major_cv_image(major_cv_image, cur_training_phase, mp4_video_metrics_info)
         major_cv_image = self._plot_agents_on_major_cv_image(major_cv_image, mp4_video_metrics_info)
         return cv2.cvtColor(major_cv_image, cv2.COLOR_BGRA2RGB)

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/training_image_editing.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/training_image_editing.py
@@ -63,7 +63,7 @@ class TrainingImageEditing(ImageEditingInterface):
         major_cv_image = utils.apply_gradient(major_cv_image, self.gradient_alpha_rgb_mul,
                                               self.one_minus_gradient_alpha)
         
-        if rospy.get_param('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower in ('true'):
+        if rospy.get_param('ENABLE_EXTRA_KVS_OVERLAY', 'False').lower() in ('true'):
             width, height = IconographicImageSize.FULL_IMAGE_SIZE.value
             major_cv_image = utils.plot_rectangle(major_cv_image, 0, 0, width, 85, RaceCarColorToRGB.Black.value )
             

--- a/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/utils.py
+++ b/bundle/src/deepracer_simulation_environment/scripts/mp4_saving/utils.py
@@ -48,6 +48,26 @@ def plot_circle(image, x_pixel, y_pixel, color_rgb):
     thickness = -1
     return cv2.circle(image, center_coordinates, RACECAR_CIRCLE_RADIUS, color_rgb, thickness)
 
+def plot_rectangle(image, start_x_pixel, start_y_pixel, end_x_pixel, end_y_pixel, color_rgb):
+    """Function used to draw a rectangle given the start and end pixel (x, y) values
+    and the color of the rectangle
+
+    Args:
+        image (Image): Top camera image
+        start_x_pixel (int): X value in the image start pixel
+        start_y_pixel (int): Y value in the image start pixel
+        end_x_pixel (int): X value in the image end pixel
+        end_y_pixel (int): Y value in the image end pixel
+        color_rgb (tuple): RGB value in the form of tuple (255, 255, 255)
+
+    Returns:
+        Image: Edited image with the rectangle
+    """
+    start_coordinates = (int(start_x_pixel), int(start_y_pixel))
+    end_coordinates = (int(end_x_pixel), int(end_y_pixel))
+    thickness = -1
+    return cv2.rectangle(image, start_coordinates, end_coordinates, color_rgb, thickness)
+
 def get_font(font_name, font_size):
     """Helper method that returns an ImageFont object for the desired font if
        available otherwise returns default font

--- a/bundle/src/deepracer_simulation_environment/srv/VideoMetricsSrv.srv
+++ b/bundle/src/deepracer_simulation_environment/srv/VideoMetricsSrv.srv
@@ -2,9 +2,11 @@
 float32 lap_counter
 float32 completion_percentage
 int32 reset_counter
+float32 speed
 float32 throttle
 float32 steering
 float32 best_lap_time
+float32 last_lap_time
 float32 total_evaluation_time
 bool done
 float32 x


### PR DESCRIPTION
- rospy param `ENABLE_EXTRA_KVS_OVERLAY` to enable additional on-screen overlay in the KVS stream
- enables use of `DR_TRAIN_BEST_MODEL_METRIC=laptime` which will use the mean laptime of completed eval laps. 