### PR TITLE
Improve reward function validation

### DIFF
--- a/docker/files/ml-code/reward_func_validator/test_reward_function.py
+++ b/docker/files/ml-code/reward_func_validator/test_reward_function.py
@@ -119,7 +119,7 @@ def run_flake8():
                 REWARD_FUNCTION_PATH,
                 "--format=%(code)s:%(row)d:%(text)s",
                 "--select=E,F",
-                "--ignore=E5,E226,E261",  # ignore stylistic errors
+                "--ignore=E2,E3,E4,E5,W,F401,F841",  # ignore stylistic errors, keep E1 (indentation) and F (logic) except unused imports/variables
             ],
             capture_output=True,
             text=True,


### PR DESCRIPTION
This pull request updates the flake8 linting configuration in the `run_flake8` function to adjust which error codes are ignored during linting. The main goal is to focus linting on indentation and logic errors, while ignoring stylistic issues and certain warnings.

**Linting configuration changes:**

* In `test_reward_function.py`, the flake8 invocation now ignores a broader set of stylistic errors (E2, E3, E4, E5), as well as warnings (W), unused imports (F401), and unused variables (F841), but keeps checks for indentation (E1) and most logic errors (F), except for the specified exceptions.