### PR TITLE
Improved Build

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 {
-    "simapp" : "6.0.3-dev",
+    "simapp" : "6.0.3",
     "deepracer-on-aws" : "v1.0.12"
 }

--- a/build-droa.sh
+++ b/build-droa.sh
@@ -34,6 +34,19 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 DROA_VERSION=$(jq -r '."deepracer-on-aws"' "$DIR/VERSION")
 SIMAPP_VERSION=$(jq -r '.simapp' "$DIR/VERSION")
 
+case "$(uname -m)" in
+x86_64|amd64)
+    SIMAPP_ARCH="amd64"
+    ;;
+aarch64|arm64)
+    SIMAPP_ARCH="arm64"
+    ;;
+*)
+    echo "Unsupported host architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
 if [ -z "$REGISTRY" ] || [ -z "$PREFIX" ]; then
     REPO="${REGISTRY}${PREFIX}"
 else
@@ -43,11 +56,11 @@ fi
 echo "Building deepracer-on-aws images version ${DROA_VERSION} under ${REPO}"
 
 # --- SimApp (cpu) ---
-SIMAPP_BUILD_IMG="${SIMAPP_PREFIX}/deepracer-simapp:${SIMAPP_VERSION}-cpu"
+SIMAPP_BUILD_IMG="${SIMAPP_PREFIX}/deepracer-simapp:${SIMAPP_VERSION}-cpu-${SIMAPP_ARCH}"
 SIMAPP_IMG="${REPO}/deepracer-on-aws-simapp:${DROA_VERSION}"
-if [ "$(docker images -q ${SIMAPP_BUILD_IMG} 2>/dev/null)" == "" ] || [ -n "${OPT_NOCACHE}" ]; then
+if [ "$(docker images -q ${SIMAPP_BUILD_IMG} 2>/dev/null)" == "" ] || [ -n "${OPT_NOCACHE:-}" ]; then
     echo "SimApp image ${SIMAPP_BUILD_IMG} not found - running build.sh..."
-    "$DIR/build.sh" -a cpu -p "${SIMAPP_PREFIX}" ${OPT_NOCACHE:+-f}
+    "$DIR/build.sh" -a cpu --platform "linux/${SIMAPP_ARCH}" -p "${SIMAPP_PREFIX}" ${OPT_NOCACHE:+-f}
 else
     echo "SimApp image ${SIMAPP_BUILD_IMG} already exists, skipping build."
 fi

--- a/build-droa.sh
+++ b/build-droa.sh
@@ -6,25 +6,65 @@ function ctrl_c() {
     exit 1
 }
 
-set -e
+set -euo pipefail
 
 REGISTRY="public.ecr.aws"
 PREFIX="deepracer-community"
-SIMAPP_PREFIX="awsdeepracercommunity"
+SIMAPP_PREFIX="${SIMAPP_PREFIX:-awsdeepracercommunity}"
+SIMAPP_ARCH="${SIMAPP_ARCH:-amd64}"
+BUILD_SIMAPP="yes"
+BUILD_VALIDATORS="yes"
 
-while getopts ":fp:r:" opt; do
-    case $opt in
-    p)
-        PREFIX="$OPTARG"
+function usage() {
+    cat <<EOF
+Usage: $0 [-p prefix] [-r registry] [-s simapp-prefix] [-f] [--push] [--simapp-only|--validators-only]
+  -p, --prefix           Repository prefix / namespace under the target registry
+  -r, --registry         Target registry (for example 123456789012.dkr.ecr.eu-central-1.amazonaws.com)
+  -s, --simapp-prefix    Source repository prefix for the existing simapp cpu-amd64 image
+  -f, --no-cache         Disable Docker build cache for validator builds
+      --push             Push the resulting images to the target registry
+      --simapp-only      Only tag/push the DROA simapp image
+      --validators-only  Only build/push the validator images
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -p|--prefix)
+        PREFIX="$2"
+        shift 2
         ;;
-    r)
-        REGISTRY="$OPTARG"
+    -r|--registry)
+        REGISTRY="$2"
+        shift 2
         ;;
-    f)
+    -s|--simapp-prefix)
+        SIMAPP_PREFIX="$2"
+        shift 2
+        ;;
+    -f|--no-cache)
         OPT_NOCACHE="--no-cache"
+        shift
         ;;
-    \?)
-        echo "Invalid option -$OPTARG" >&2
+    --push)
+        OPT_PUSH="yes"
+        shift
+        ;;
+    --simapp-only)
+        BUILD_VALIDATORS=""
+        shift
+        ;;
+    --validators-only)
+        BUILD_SIMAPP=""
+        shift
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown option $1" >&2
+        usage
         exit 1
         ;;
     esac
@@ -34,19 +74,6 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 DROA_VERSION=$(jq -r '."deepracer-on-aws"' "$DIR/VERSION")
 SIMAPP_VERSION=$(jq -r '.simapp' "$DIR/VERSION")
 
-case "$(uname -m)" in
-x86_64|amd64)
-    SIMAPP_ARCH="amd64"
-    ;;
-aarch64|arm64)
-    SIMAPP_ARCH="arm64"
-    ;;
-*)
-    echo "Unsupported host architecture: $(uname -m)" >&2
-    exit 1
-    ;;
-esac
-
 if [ -z "$REGISTRY" ] || [ -z "$PREFIX" ]; then
     REPO="${REGISTRY}${PREFIX}"
 else
@@ -55,31 +82,47 @@ fi
 
 echo "Building deepracer-on-aws images version ${DROA_VERSION} under ${REPO}"
 
-# --- SimApp (cpu) ---
-SIMAPP_BUILD_IMG="${SIMAPP_PREFIX}/deepracer-simapp:${SIMAPP_VERSION}-cpu-${SIMAPP_ARCH}"
-SIMAPP_IMG="${REPO}/deepracer-on-aws-simapp:${DROA_VERSION}"
-if [ "$(docker images -q ${SIMAPP_BUILD_IMG} 2>/dev/null)" == "" ] || [ -n "${OPT_NOCACHE:-}" ]; then
-    echo "SimApp image ${SIMAPP_BUILD_IMG} not found - running build.sh..."
-    "$DIR/build.sh" -a cpu --platform "linux/${SIMAPP_ARCH}" -p "${SIMAPP_PREFIX}" ${OPT_NOCACHE:+-f}
-else
-    echo "SimApp image ${SIMAPP_BUILD_IMG} already exists, skipping build."
+if [ -n "${BUILD_SIMAPP}" ]; then
+    SIMAPP_BUILD_IMG="${SIMAPP_PREFIX}/deepracer-simapp:${SIMAPP_VERSION}-cpu-${SIMAPP_ARCH}"
+    SIMAPP_IMG="${REPO}/deepracer-on-aws-simapp:${DROA_VERSION}"
+
+    if [ "$(docker images -q ${SIMAPP_BUILD_IMG} 2>/dev/null)" == "" ] || [ -n "${OPT_NOCACHE:-}" ]; then
+        echo "SimApp image ${SIMAPP_BUILD_IMG} not found locally - running build.sh..."
+        "$DIR/build.sh" -a cpu --platform "linux/${SIMAPP_ARCH}" -p "${SIMAPP_PREFIX}" ${OPT_NOCACHE:+-f}
+    else
+        echo "SimApp image ${SIMAPP_BUILD_IMG} already exists, reusing it for the DROA tag."
+    fi
+
+    docker tag "${SIMAPP_BUILD_IMG}" "${SIMAPP_IMG}"
+
+    if [ -n "${OPT_PUSH:-}" ]; then
+        docker push "${SIMAPP_IMG}"
+    fi
 fi
-docker tag "${SIMAPP_BUILD_IMG}" "${SIMAPP_IMG}"
 
-# --- Model Validation ---
-echo "Building model-validation image..."
-docker buildx build . ${OPT_NOCACHE} \
-    -t ${REPO}/deepracer-on-aws-model-validation:${DROA_VERSION} \
-    -f docker/Dockerfile.model-validation \
-    --build-arg DROA_VERSION=${DROA_VERSION}
+if [ -n "${BUILD_VALIDATORS}" ]; then
+    VALIDATOR_OUTPUT="--load"
+    if [ -n "${OPT_PUSH:-}" ]; then
+        VALIDATOR_OUTPUT="--push"
+    fi
 
-# --- Reward Function Validation ---
-echo "Building reward-function-validation image..."
-docker buildx build . ${OPT_NOCACHE} \
-    -t ${REPO}/deepracer-on-aws-reward-function-validation:${DROA_VERSION} \
-    -f docker/Dockerfile.reward-function-validation
+    echo "Building model-validation image..."
+    docker buildx build . ${OPT_NOCACHE:-} ${VALIDATOR_OUTPUT} --platform linux/amd64 \
+        -t ${REPO}/deepracer-on-aws-model-validation:${DROA_VERSION} \
+        -f docker/Dockerfile.model-validation \
+        --build-arg DROA_VERSION=${DROA_VERSION}
+
+    echo "Building reward-function-validation image..."
+    docker buildx build . ${OPT_NOCACHE:-} ${VALIDATOR_OUTPUT} --platform linux/amd64 \
+        -t ${REPO}/deepracer-on-aws-reward-function-validation:${DROA_VERSION} \
+        -f docker/Dockerfile.reward-function-validation
+fi
 
 echo "Done. Built images:"
-echo "  ${REPO}/deepracer-on-aws-simapp:${DROA_VERSION}"
-echo "  ${REPO}/deepracer-on-aws-model-validation:${DROA_VERSION}"
-echo "  ${REPO}/deepracer-on-aws-reward-function-validation:${DROA_VERSION}"
+if [ -n "${BUILD_SIMAPP}" ]; then
+    echo "  ${REPO}/deepracer-on-aws-simapp:${DROA_VERSION}"
+fi
+if [ -n "${BUILD_VALIDATORS}" ]; then
+    echo "  ${REPO}/deepracer-on-aws-model-validation:${DROA_VERSION}"
+    echo "  ${REPO}/deepracer-on-aws-reward-function-validation:${DROA_VERSION}"
+fi

--- a/build.sh
+++ b/build.sh
@@ -6,50 +6,122 @@ function ctrl_c() {
     exit 1
 }
 
-set -e
+set -euo pipefail
 
 PREFIX="awsdeepracercommunity"
-ARCH="cpu gpu"
+VARIANTS="cpu gpu"
+PLATFORM=""
 
-while getopts ":a:fcp:" opt; do
-    case $opt in
-    a)
-        ARCH="$OPTARG"
+function usage() {
+    cat <<EOF
+Usage: $0 [-a "cpu gpu"] [--platform linux/amd64|linux/arm64] [-p prefix] [-f] [-c] [--push]
+  -a, --variant       Space-separated variants to build (default: "cpu gpu")
+      --platform      Docker platform to build for (default: native host)
+  -p, --prefix        Image prefix / repository namespace
+  -f, --no-cache      Disable Docker build cache
+  -c, --rebuild-core  Force rebuild of the core builder image
+      --push          Push built leaf images after the build completes
+EOF
+}
+
+function detect_platform() {
+    case "$(uname -m)" in
+    x86_64|amd64)
+        echo "linux/amd64"
         ;;
-    p)
-        PREFIX="$OPTARG"
+    aarch64|arm64)
+        echo "linux/arm64"
         ;;
-    f)
+    *)
+        echo "Unsupported host architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+    esac
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -a|--variant)
+        VARIANTS="$2"
+        shift 2
+        ;;
+    --platform)
+        PLATFORM="$2"
+        shift 2
+        ;;
+    -p|--prefix)
+        PREFIX="$2"
+        shift 2
+        ;;
+    -f|--no-cache)
         OPT_NOCACHE="--no-cache"
+        shift
         ;;
-    c)
+    -c|--rebuild-core)
         OPT_CORE="yes"
+        shift
         ;;
-    \?)
-        echo "Invalid option -$OPTARG" >&2
+    --push)
+        OPT_PUSH="yes"
+        shift
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown option $1" >&2
+        usage
         exit 1
         ;;
     esac
 done
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-VERSION=$(jq -r '.simapp' $DIR/VERSION)
+VERSION=$(jq -r '.simapp' "$DIR/VERSION")
+PLATFORM="${PLATFORM:-$(detect_platform)}"
 
-if [ "$(docker images -q ${PREFIX}/deepracer-simapp-build-core:latest 2> /dev/null)" == "" ] || [ -n "${OPT_NOCACHE}" ] || [ -n "${OPT_CORE}" ]; then
-    echo "Preparing core builder image ${PREFIX}/deepracer-simapp-build-core:latest..."
-    docker buildx build ${OPT_NOCACHE} -t ${PREFIX}/deepracer-simapp-build-core:latest -f docker/Dockerfile.build-core .
+case "$PLATFORM" in
+linux/amd64)
+    TARGET_ARCH="amd64"
+    ;;
+linux/arm64)
+    TARGET_ARCH="arm64"
+    ;;
+*)
+    echo "Unsupported platform ${PLATFORM}" >&2
+    exit 1
+    ;;
+esac
+
+CORE_TAG="latest-${TARGET_ARCH}"
+BUNDLE_TAG="latest-${TARGET_ARCH}"
+
+if [ "$(docker images -q ${PREFIX}/deepracer-simapp-build-core:${CORE_TAG} 2>/dev/null)" == "" ] || [ -n "${OPT_NOCACHE:-}" ] || [ -n "${OPT_CORE:-}" ]; then
+    echo "Preparing core builder image ${PREFIX}/deepracer-simapp-build-core:${CORE_TAG} for ${PLATFORM}..."
+    docker buildx build ${OPT_NOCACHE:-} --load --platform "${PLATFORM}" \
+        -t ${PREFIX}/deepracer-simapp-build-core:${CORE_TAG} \
+        -f docker/Dockerfile.build-core .
 else
-    echo "Core builder image ${PREFIX}/deepracer-simapp-build-core:latest already exists."
+    echo "Core builder image ${PREFIX}/deepracer-simapp-build-core:${CORE_TAG} already exists."
 fi
 
-echo "Preparing bundle distribution..."
-docker buildx build ${OPT_NOCACHE} -t ${PREFIX}/deepracer-simapp-build-bundle:latest -f docker/Dockerfile.build-bundle --build-arg CORE_PREFIX=${PREFIX} .
+echo "Preparing bundle distribution for ${PLATFORM}..."
+docker buildx build ${OPT_NOCACHE:-} --load --platform "${PLATFORM}" \
+    -t ${PREFIX}/deepracer-simapp-build-bundle:${BUNDLE_TAG} \
+    -f docker/Dockerfile.build-bundle \
+    --build-arg CORE_PREFIX=${PREFIX} \
+    --build-arg CORE_TAG=${CORE_TAG} .
 
-echo "Preparing docker images for [$ARCH]"
+echo "Preparing docker images for [${VARIANTS}] on ${PLATFORM}"
 
-for a in $ARCH; do
-    case $a in
+for variant in $VARIANTS; do
+    case $variant in
     gpu)
+        if [ "${TARGET_ARCH}" != "amd64" ]; then
+            echo "Skipping gpu build on ${PLATFORM}; only linux/amd64 is supported."
+            continue
+        fi
         CORE_IMG="nvcr.io/nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04"
         NVCC_VER="cuda-nvcc-12-6"
         ;;
@@ -57,13 +129,26 @@ for a in $ARCH; do
         CORE_IMG="ubuntu:24.04"
         NVCC_VER=""
         ;;
+    *)
+        echo "Unknown variant ${variant}" >&2
+        exit 1
+        ;;
     esac
 
+    IMAGE_TAG="${PREFIX}/deepracer-simapp:${VERSION}-${variant}-${TARGET_ARCH}"
+
     set -x
-    docker buildx build . ${OPT_NOCACHE} -t $PREFIX/deepracer-simapp:${VERSION}-${a} -f docker/Dockerfile.combined \
-        --build-arg IMG_VERSION=${VERSION} \
-        --build-arg BUNDLE_PREFIX=${PREFIX} \
-        --build-arg CORE_IMG=${CORE_IMG} \
-        --build-arg NVCC_VER=${NVCC_VER}
+    docker buildx build . ${OPT_NOCACHE:-} --load --platform "${PLATFORM}" \
+        -t "${IMAGE_TAG}" \
+        -f docker/Dockerfile.combined \
+        --build-arg IMG_VERSION="${VERSION}" \
+        --build-arg BUNDLE_PREFIX="${PREFIX}" \
+        --build-arg BUNDLE_TAG="${BUNDLE_TAG}" \
+        --build-arg CORE_IMG="${CORE_IMG}" \
+        --build-arg NVCC_VER="${NVCC_VER}"
     set +x
+
+    if [ -n "${OPT_PUSH:-}" ]; then
+        docker push "${IMAGE_TAG}"
+    fi
 done

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,11 +2,24 @@ version: 0.2
 phases:
   pre_build:
     commands:
-        - docker login --username ${DOCKER_HUB_USER} --password ${DOCKER_HUB_KEY} 
-        - apt-get update && apt-get install gawk
+      - echo "${DOCKER_HUB_KEY}" | docker login --username "${DOCKER_HUB_USER}" --password-stdin
+      - docker buildx version
+      - docker buildx inspect --bootstrap
   build:
     commands:
-       - bash build.sh -a "${CPU_FLAGS}" -p ${DOCKER_HUB_REPO} -f
-  post_build:
-    commands:
-       - bash push.sh -a "${CPU_FLAGS}" -p ${DOCKER_HUB_REPO}
+      - |
+        case "${BUILD_TARGET}" in
+          amd64)
+            bash build.sh --platform linux/amd64 -a "cpu gpu" -p "${DOCKER_HUB_REPO}" --push ${NO_CACHE:+--no-cache}
+            ;;
+          arm64)
+            bash build.sh --platform linux/arm64 -a "cpu" -p "${DOCKER_HUB_REPO}" --push ${NO_CACHE:+--no-cache}
+            ;;
+          manifests)
+            bash publish-manifests.sh -a "cpu gpu" -p "${DOCKER_HUB_REPO}"
+            ;;
+          *)
+            echo "Unknown BUILD_TARGET=${BUILD_TARGET}" >&2
+            exit 1
+            ;;
+        esac

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,11 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - echo "${DOCKER_HUB_KEY}" | docker login --username "${DOCKER_HUB_USER}" --password-stdin
+      - printf '%s' "${DOCKER_HUB_KEY}" | docker login --username "${DOCKER_HUB_USER}" --password-stdin
+      - |
+        if [ -n "${ECR_REGISTRY:-}" ]; then
+          aws ecr get-login-password --region "${AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+        fi
       - docker buildx version
       - docker buildx inspect --bootstrap
   build:
@@ -11,12 +15,18 @@ phases:
         case "${BUILD_TARGET}" in
           amd64)
             bash build.sh --platform linux/amd64 -a "cpu gpu" -p "${DOCKER_HUB_REPO}" --push ${NO_CACHE:+--no-cache}
+            if [ -n "${ECR_REGISTRY:-}" ]; then
+              bash build-droa.sh --simapp-only --push -r "${ECR_REGISTRY}" -p "${ECR_REPO_PREFIX}" -s "${DOCKER_HUB_REPO}" ${NO_CACHE:+-f}
+            fi
             ;;
           arm64)
             bash build.sh --platform linux/arm64 -a "cpu" -p "${DOCKER_HUB_REPO}" --push ${NO_CACHE:+--no-cache}
             ;;
           manifests)
             bash publish-manifests.sh -a "cpu gpu" -p "${DOCKER_HUB_REPO}"
+            ;;
+          validators)
+            bash build-droa.sh --validators-only --push -r "${ECR_REGISTRY}" -p "${ECR_REPO_PREFIX}" -s "${DOCKER_HUB_REPO}" ${NO_CACHE:+-f}
             ;;
           *)
             echo "Unknown BUILD_TARGET=${BUILD_TARGET}" >&2

--- a/cloudformation/simapp-build-pipeline.yml
+++ b/cloudformation/simapp-build-pipeline.yml
@@ -1,0 +1,346 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Small CodePipeline + CodeBuild stack for DeepRacer simapp multi-arch Docker builds
+  and transparent Docker Hub manifest publishing.
+
+Parameters:
+  ProjectName:
+    Type: String
+    Default: deepracer-simapp
+    Description: Prefix used for pipeline and CodeBuild project names.
+
+  GitHubConnectionArn:
+    Type: String
+    Description: Existing CodeStar connection ARN for the GitHub repository.
+
+  RepositoryOwner:
+    Type: String
+    Description: GitHub organization or user name.
+
+  RepositoryName:
+    Type: String
+    Description: GitHub repository name.
+
+  RepositoryBranch:
+    Type: String
+    Default: main
+    Description: Git branch that triggers the pipeline.
+
+  DockerHubRepo:
+    Type: String
+    Default: awsdeepracercommunity
+    Description: Docker Hub namespace/repository prefix used by the build scripts.
+
+  DockerHubSecretArn:
+    Type: String
+    Description: >-
+      Secrets Manager ARN containing the Docker Hub credentials as JSON, for example
+      {"username":"...","token":"..."}.
+
+  DockerHubUsernameKey:
+    Type: String
+    Default: username
+    Description: JSON key inside the Docker Hub secret for the Docker Hub username.
+
+  DockerHubTokenKey:
+    Type: String
+    Default: token
+    Description: JSON key inside the Docker Hub secret for the Docker Hub access token or password.
+
+  BuildComputeType:
+    Type: String
+    Default: BUILD_GENERAL1_LARGE
+    AllowedValues:
+      - BUILD_GENERAL1_SMALL
+      - BUILD_GENERAL1_MEDIUM
+      - BUILD_GENERAL1_LARGE
+      - BUILD_GENERAL1_XLARGE
+      - BUILD_GENERAL1_2XLARGE
+    Description: CodeBuild compute size to use for all jobs.
+
+  Amd64BuildImage:
+    Type: String
+    Default: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+    Description: Docker image for the amd64 CodeBuild environment.
+
+  Arm64BuildImage:
+    Type: String
+    Default: aws/codebuild/amazonlinux2-aarch64-standard:3.0
+    Description: Docker image for the arm64 CodeBuild environment.
+
+  BuildTimeoutMinutes:
+    Type: Number
+    Default: 120
+    MinValue: 5
+    MaxValue: 480
+    Description: Timeout for each CodeBuild project in minutes.
+
+Resources:
+  ArtifactBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      VersioningConfiguration:
+        Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  CodeBuildServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${ProjectName}-codebuild-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub '${ProjectName}-codebuild-policy'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
+                  - s3:GetBucketLocation
+                  - s3:GetBucketAcl
+                Resource:
+                  - !GetAtt ArtifactBucket.Arn
+                  - !Sub '${ArtifactBucket.Arn}/*'
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Ref DockerHubSecretArn
+
+  CodePipelineServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${ProjectName}-codepipeline-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub '${ProjectName}-codepipeline-policy'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetBucketVersioning
+                  - s3:GetBucketLocation
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
+                Resource:
+                  - !GetAtt ArtifactBucket.Arn
+                  - !Sub '${ArtifactBucket.Arn}/*'
+              - Effect: Allow
+                Action:
+                  - codebuild:StartBuild
+                  - codebuild:BatchGetBuilds
+                Resource:
+                  - !GetAtt Amd64BuildProject.Arn
+                  - !GetAtt Arm64BuildProject.Arn
+                  - !GetAtt ManifestBuildProject.Arn
+              - Effect: Allow
+                Action:
+                  - codestar-connections:UseConnection
+                  - codeconnections:UseConnection
+                Resource: !Ref GitHubConnectionArn
+
+  Amd64BuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub '${ProjectName}-amd64'
+      ServiceRole: !GetAtt CodeBuildServiceRole.Arn
+      TimeoutInMinutes: !Ref BuildTimeoutMinutes
+      Artifacts:
+        Type: CODEPIPELINE
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: buildspec.yml
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: !Ref BuildComputeType
+        Image: !Ref Amd64BuildImage
+        PrivilegedMode: true
+        EnvironmentVariables:
+          - Name: BUILD_TARGET
+            Type: PLAINTEXT
+            Value: amd64
+          - Name: DOCKER_HUB_REPO
+            Type: PLAINTEXT
+            Value: !Ref DockerHubRepo
+          - Name: DOCKER_HUB_USER
+            Type: SECRETS_MANAGER
+            Value: !Sub '${DockerHubSecretArn}:${DockerHubUsernameKey}'
+          - Name: DOCKER_HUB_KEY
+            Type: SECRETS_MANAGER
+            Value: !Sub '${DockerHubSecretArn}:${DockerHubTokenKey}'
+
+  Arm64BuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub '${ProjectName}-arm64'
+      ServiceRole: !GetAtt CodeBuildServiceRole.Arn
+      TimeoutInMinutes: !Ref BuildTimeoutMinutes
+      Artifacts:
+        Type: CODEPIPELINE
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: buildspec.yml
+      Environment:
+        Type: ARM_CONTAINER
+        ComputeType: !Ref BuildComputeType
+        Image: !Ref Arm64BuildImage
+        PrivilegedMode: true
+        EnvironmentVariables:
+          - Name: BUILD_TARGET
+            Type: PLAINTEXT
+            Value: arm64
+          - Name: DOCKER_HUB_REPO
+            Type: PLAINTEXT
+            Value: !Ref DockerHubRepo
+          - Name: DOCKER_HUB_USER
+            Type: SECRETS_MANAGER
+            Value: !Sub '${DockerHubSecretArn}:${DockerHubUsernameKey}'
+          - Name: DOCKER_HUB_KEY
+            Type: SECRETS_MANAGER
+            Value: !Sub '${DockerHubSecretArn}:${DockerHubTokenKey}'
+
+  ManifestBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub '${ProjectName}-manifests'
+      ServiceRole: !GetAtt CodeBuildServiceRole.Arn
+      TimeoutInMinutes: !Ref BuildTimeoutMinutes
+      Artifacts:
+        Type: CODEPIPELINE
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: buildspec.yml
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: !Ref BuildComputeType
+        Image: !Ref Amd64BuildImage
+        PrivilegedMode: true
+        EnvironmentVariables:
+          - Name: BUILD_TARGET
+            Type: PLAINTEXT
+            Value: manifests
+          - Name: DOCKER_HUB_REPO
+            Type: PLAINTEXT
+            Value: !Ref DockerHubRepo
+          - Name: DOCKER_HUB_USER
+            Type: SECRETS_MANAGER
+            Value: !Sub '${DockerHubSecretArn}:${DockerHubUsernameKey}'
+          - Name: DOCKER_HUB_KEY
+            Type: SECRETS_MANAGER
+            Value: !Sub '${DockerHubSecretArn}:${DockerHubTokenKey}'
+
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      Name: !Ref ProjectName
+      RoleArn: !GetAtt CodePipelineServiceRole.Arn
+      RestartExecutionOnUpdate: true
+      ArtifactStore:
+        Type: S3
+        Location: !Ref ArtifactBucket
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: SourceFromGitHub
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Provider: CodeStarSourceConnection
+                Version: '1'
+              Configuration:
+                ConnectionArn: !Ref GitHubConnectionArn
+                FullRepositoryId: !Sub '${RepositoryOwner}/${RepositoryName}'
+                BranchName: !Ref RepositoryBranch
+                DetectChanges: 'true'
+              OutputArtifacts:
+                - Name: SourceArtifact
+              RunOrder: 1
+        - Name: BuildImages
+          Actions:
+            - Name: BuildAmd64
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: '1'
+              Configuration:
+                ProjectName: !Ref Amd64BuildProject
+              InputArtifacts:
+                - Name: SourceArtifact
+              RunOrder: 1
+            - Name: BuildArm64
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: '1'
+              Configuration:
+                ProjectName: !Ref Arm64BuildProject
+              InputArtifacts:
+                - Name: SourceArtifact
+              RunOrder: 1
+        - Name: PublishManifests
+          Actions:
+            - Name: PublishTransparentTags
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: '1'
+              Configuration:
+                ProjectName: !Ref ManifestBuildProject
+              InputArtifacts:
+                - Name: SourceArtifact
+              RunOrder: 1
+
+Outputs:
+  PipelineName:
+    Description: Name of the created CodePipeline pipeline.
+    Value: !Ref Pipeline
+
+  ArtifactBucketName:
+    Description: S3 bucket used for CodePipeline artifacts.
+    Value: !Ref ArtifactBucket
+
+  Amd64ProjectName:
+    Description: Name of the amd64 CodeBuild project.
+    Value: !Ref Amd64BuildProject
+
+  Arm64ProjectName:
+    Description: Name of the arm64 CodeBuild project.
+    Value: !Ref Arm64BuildProject
+
+  ManifestProjectName:
+    Description: Name of the manifest publishing CodeBuild project.
+    Value: !Ref ManifestBuildProject

--- a/cloudformation/simapp-build-pipeline.yml
+++ b/cloudformation/simapp-build-pipeline.yml
@@ -31,21 +31,18 @@ Parameters:
     Default: awsdeepracercommunity
     Description: Docker Hub namespace/repository prefix used by the build scripts.
 
+  DockerHubUsername:
+    Type: String
+    Description: Docker Hub username used for `docker login`.
+
   DockerHubSecretArn:
     Type: String
-    Description: >-
-      Secrets Manager ARN containing the Docker Hub credentials as JSON, for example
-      {"username":"...","token":"..."}.
+    Description: Base Secrets Manager ARN containing the Docker Hub secret object.
 
-  DockerHubUsernameKey:
+  DockerHubSecretKey:
     Type: String
-    Default: username
-    Description: JSON key inside the Docker Hub secret for the Docker Hub username.
-
-  DockerHubTokenKey:
-    Type: String
-    Default: token
-    Description: JSON key inside the Docker Hub secret for the Docker Hub access token or password.
+    Default: docker-hub-password
+    Description: JSON key inside the Secrets Manager value that holds the Docker Hub password or access token.
 
   BuildComputeType:
     Type: String
@@ -128,7 +125,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - secretsmanager:GetSecretValue
-                Resource: !Ref DockerHubSecretArn
+                Resource:
+                  - !Ref DockerHubSecretArn
+                  - !Sub '${DockerHubSecretArn}*'
 
   CodePipelineServiceRole:
     Type: AWS::IAM::Role
@@ -194,11 +193,11 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref DockerHubRepo
           - Name: DOCKER_HUB_USER
-            Type: SECRETS_MANAGER
-            Value: !Sub '${DockerHubSecretArn}:${DockerHubUsernameKey}'
+            Type: PLAINTEXT
+            Value: !Ref DockerHubUsername
           - Name: DOCKER_HUB_KEY
             Type: SECRETS_MANAGER
-            Value: !Sub '${DockerHubSecretArn}:${DockerHubTokenKey}'
+            Value: !Sub '${DockerHubSecretArn}:${DockerHubSecretKey}'
 
   Arm64BuildProject:
     Type: AWS::CodeBuild::Project
@@ -224,11 +223,11 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref DockerHubRepo
           - Name: DOCKER_HUB_USER
-            Type: SECRETS_MANAGER
-            Value: !Sub '${DockerHubSecretArn}:${DockerHubUsernameKey}'
+            Type: PLAINTEXT
+            Value: !Ref DockerHubUsername
           - Name: DOCKER_HUB_KEY
             Type: SECRETS_MANAGER
-            Value: !Sub '${DockerHubSecretArn}:${DockerHubTokenKey}'
+            Value: !Sub '${DockerHubSecretArn}:${DockerHubSecretKey}'
 
   ManifestBuildProject:
     Type: AWS::CodeBuild::Project
@@ -254,11 +253,11 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref DockerHubRepo
           - Name: DOCKER_HUB_USER
-            Type: SECRETS_MANAGER
-            Value: !Sub '${DockerHubSecretArn}:${DockerHubUsernameKey}'
+            Type: PLAINTEXT
+            Value: !Ref DockerHubUsername
           - Name: DOCKER_HUB_KEY
             Type: SECRETS_MANAGER
-            Value: !Sub '${DockerHubSecretArn}:${DockerHubTokenKey}'
+            Value: !Sub '${DockerHubSecretArn}:${DockerHubSecretKey}'
 
   Pipeline:
     Type: AWS::CodePipeline::Pipeline

--- a/cloudformation/simapp-build-pipeline.yml
+++ b/cloudformation/simapp-build-pipeline.yml
@@ -9,6 +9,22 @@ Parameters:
     Default: deepracer-simapp
     Description: Prefix used for pipeline and CodeBuild project names.
 
+  EnableEcrPublishing:
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: Set to true to publish DROA and validator images to private ECR.
+
+  CreateEcrRepositories:
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: Set to true only if the private ECR repositories should be created by this stack.
+
   GitHubConnectionArn:
     Type: String
     Description: Existing CodeStar connection ARN for the GitHub repository.
@@ -44,6 +60,11 @@ Parameters:
     Default: docker-hub-password
     Description: JSON key inside the Secrets Manager value that holds the Docker Hub password or access token.
 
+  EcrRepositoryPrefix:
+    Type: String
+    Default: ''
+    Description: Optional prefix for the private ECR repositories used for DROA and validator images. Leave empty to publish at the registry root.
+
   BuildComputeType:
     Type: String
     Default: BUILD_GENERAL1_LARGE
@@ -72,6 +93,13 @@ Parameters:
     MaxValue: 480
     Description: Timeout for each CodeBuild project in minutes.
 
+Conditions:
+  EnableEcrPublishingCondition: !Equals [!Ref EnableEcrPublishing, 'true']
+  ShouldCreateEcrRepositories: !And
+    - !Condition EnableEcrPublishingCondition
+    - !Equals [!Ref CreateEcrRepositories, 'true']
+  HasEcrRepositoryPrefix: !Not [!Equals [!Ref EcrRepositoryPrefix, '']]
+
 Resources:
   ArtifactBucket:
     Type: AWS::S3::Bucket
@@ -89,6 +117,48 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+
+  DroaSimappRepository:
+    Condition: ShouldCreateEcrRepositories
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !If
+        - HasEcrRepositoryPrefix
+        - !Sub '${EcrRepositoryPrefix}/deepracer-on-aws-simapp'
+        - deepracer-on-aws-simapp
+      ImageTagMutability: MUTABLE
+      ImageScanningConfiguration:
+        ScanOnPush: true
+      EncryptionConfiguration:
+        EncryptionType: AES256
+
+  ModelValidationRepository:
+    Condition: ShouldCreateEcrRepositories
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !If
+        - HasEcrRepositoryPrefix
+        - !Sub '${EcrRepositoryPrefix}/deepracer-on-aws-model-validation'
+        - deepracer-on-aws-model-validation
+      ImageTagMutability: MUTABLE
+      ImageScanningConfiguration:
+        ScanOnPush: true
+      EncryptionConfiguration:
+        EncryptionType: AES256
+
+  RewardFunctionValidationRepository:
+    Condition: ShouldCreateEcrRepositories
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !If
+        - HasEcrRepositoryPrefix
+        - !Sub '${EcrRepositoryPrefix}/deepracer-on-aws-reward-function-validation'
+        - deepracer-on-aws-reward-function-validation
+      ImageTagMutability: MUTABLE
+      ImageScanningConfiguration:
+        ScanOnPush: true
+      EncryptionConfiguration:
+        EncryptionType: AES256
 
   CodeBuildServiceRole:
     Type: AWS::IAM::Role
@@ -128,6 +198,28 @@ Resources:
                 Resource:
                   - !Ref DockerHubSecretArn
                   - !Sub '${DockerHubSecretArn}*'
+              - !If
+                - EnableEcrPublishingCondition
+                - Effect: Allow
+                  Action:
+                    - ecr:GetAuthorizationToken
+                  Resource: '*'
+                - !Ref AWS::NoValue
+              - !If
+                - EnableEcrPublishingCondition
+                - Effect: Allow
+                  Action:
+                    - ecr:BatchCheckLayerAvailability
+                    - ecr:BatchGetImage
+                    - ecr:CompleteLayerUpload
+                    - ecr:DescribeImages
+                    - ecr:DescribeRepositories
+                    - ecr:GetDownloadUrlForLayer
+                    - ecr:InitiateLayerUpload
+                    - ecr:PutImage
+                    - ecr:UploadLayerPart
+                  Resource: !Sub 'arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/*'
+                - !Ref AWS::NoValue
 
   CodePipelineServiceRole:
     Type: AWS::IAM::Role
@@ -163,6 +255,7 @@ Resources:
                   - !GetAtt Amd64BuildProject.Arn
                   - !GetAtt Arm64BuildProject.Arn
                   - !GetAtt ManifestBuildProject.Arn
+                  - !If [EnableEcrPublishingCondition, !GetAtt ValidatorsBuildProject.Arn, !Ref AWS::NoValue]
               - Effect: Allow
                 Action:
                   - codestar-connections:UseConnection
@@ -198,6 +291,18 @@ Resources:
           - Name: DOCKER_HUB_KEY
             Type: SECRETS_MANAGER
             Value: !Sub '${DockerHubSecretArn}:${DockerHubSecretKey}'
+          - !If
+            - EnableEcrPublishingCondition
+            - Name: ECR_REGISTRY
+              Type: PLAINTEXT
+              Value: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com'
+            - !Ref AWS::NoValue
+          - !If
+            - EnableEcrPublishingCondition
+            - Name: ECR_REPO_PREFIX
+              Type: PLAINTEXT
+              Value: !Ref EcrRepositoryPrefix
+            - !Ref AWS::NoValue
 
   Arm64BuildProject:
     Type: AWS::CodeBuild::Project
@@ -259,6 +364,43 @@ Resources:
             Type: SECRETS_MANAGER
             Value: !Sub '${DockerHubSecretArn}:${DockerHubSecretKey}'
 
+  ValidatorsBuildProject:
+    Condition: EnableEcrPublishingCondition
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub '${ProjectName}-validators'
+      ServiceRole: !GetAtt CodeBuildServiceRole.Arn
+      TimeoutInMinutes: !Ref BuildTimeoutMinutes
+      Artifacts:
+        Type: CODEPIPELINE
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: buildspec.yml
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: !Ref BuildComputeType
+        Image: !Ref Amd64BuildImage
+        PrivilegedMode: true
+        EnvironmentVariables:
+          - Name: BUILD_TARGET
+            Type: PLAINTEXT
+            Value: validators
+          - Name: DOCKER_HUB_REPO
+            Type: PLAINTEXT
+            Value: !Ref DockerHubRepo
+          - Name: DOCKER_HUB_USER
+            Type: PLAINTEXT
+            Value: !Ref DockerHubUsername
+          - Name: DOCKER_HUB_KEY
+            Type: SECRETS_MANAGER
+            Value: !Sub '${DockerHubSecretArn}:${DockerHubSecretKey}'
+          - Name: ECR_REGISTRY
+            Type: PLAINTEXT
+            Value: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com'
+          - Name: ECR_REPO_PREFIX
+            Type: PLAINTEXT
+            Value: !Ref EcrRepositoryPrefix
+
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
@@ -309,6 +451,22 @@ Resources:
               InputArtifacts:
                 - Name: SourceArtifact
               RunOrder: 1
+        - !If
+          - EnableEcrPublishingCondition
+          - Name: PublishEcrImages
+            Actions:
+              - Name: BuildValidators
+                ActionTypeId:
+                  Category: Build
+                  Owner: AWS
+                  Provider: CodeBuild
+                  Version: '1'
+                Configuration:
+                  ProjectName: !Ref ValidatorsBuildProject
+                InputArtifacts:
+                  - Name: SourceArtifact
+                RunOrder: 1
+          - !Ref AWS::NoValue
         - Name: PublishManifests
           Actions:
             - Name: PublishTransparentTags
@@ -343,3 +501,32 @@ Outputs:
   ManifestProjectName:
     Description: Name of the manifest publishing CodeBuild project.
     Value: !Ref ManifestBuildProject
+
+  ValidatorsProjectName:
+    Condition: EnableEcrPublishingCondition
+    Description: Name of the validator ECR publishing CodeBuild project.
+    Value: !Ref ValidatorsBuildProject
+
+  DroaSimappRepositoryUri:
+    Condition: EnableEcrPublishingCondition
+    Description: ECR repository URI for the DROA simapp tag.
+    Value: !If
+      - HasEcrRepositoryPrefix
+      - !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EcrRepositoryPrefix}/deepracer-on-aws-simapp'
+      - !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/deepracer-on-aws-simapp'
+
+  ModelValidationRepositoryUri:
+    Condition: EnableEcrPublishingCondition
+    Description: ECR repository URI for the model validation image.
+    Value: !If
+      - HasEcrRepositoryPrefix
+      - !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EcrRepositoryPrefix}/deepracer-on-aws-model-validation'
+      - !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/deepracer-on-aws-model-validation'
+
+  RewardFunctionValidationRepositoryUri:
+    Condition: EnableEcrPublishingCondition
+    Description: ECR repository URI for the reward function validation image.
+    Value: !If
+      - HasEcrRepositoryPrefix
+      - !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${EcrRepositoryPrefix}/deepracer-on-aws-reward-function-validation'
+      - !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/deepracer-on-aws-reward-function-validation'

--- a/docker/Dockerfile.build-bundle
+++ b/docker/Dockerfile.build-bundle
@@ -1,5 +1,6 @@
 ARG CORE_PREFIX=awsdeepracercommunity
-FROM $CORE_PREFIX/deepracer-simapp-build-core:latest
+ARG CORE_TAG=latest
+FROM $CORE_PREFIX/deepracer-simapp-build-core:${CORE_TAG}
 
 COPY bundle/ /opt/amazon
 COPY docker/files/ml-code/ /opt/ml/code

--- a/docker/Dockerfile.combined
+++ b/docker/Dockerfile.combined
@@ -1,7 +1,8 @@
 ARG BUNDLE_PREFIX=awsdeepracercommunity
+ARG BUNDLE_TAG=latest
 ARG CORE_IMG=ubuntu:24.04
 
-FROM ${BUNDLE_PREFIX}/deepracer-simapp-build-bundle:latest AS bundle
+FROM ${BUNDLE_PREFIX}/deepracer-simapp-build-bundle:${BUNDLE_TAG} AS bundle
 FROM ${CORE_IMG}
 
 ARG NVCC_VER=""

--- a/publish-manifests.sh
+++ b/publish-manifests.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+trap ctrl_c INT
+
+function ctrl_c() {
+    echo "Requested to stop."
+    exit 1
+}
+
+set -euo pipefail
+
+PREFIX="local"
+VARIANTS="cpu gpu"
+
+function usage() {
+    cat <<EOF
+Usage: $0 [-a "cpu gpu"] [-p prefix]
+  -a, --variant   Space-separated variants to publish (default: "cpu gpu")
+  -p, --prefix    Image prefix / repository namespace
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -a|--variant)
+        VARIANTS="$2"
+        shift 2
+        ;;
+    -p|--prefix)
+        PREFIX="$2"
+        shift 2
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown option $1" >&2
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+VERSION=$(jq -r '.simapp' "$DIR/VERSION")
+
+echo "Publishing transparent docker manifests for [${VARIANTS}]"
+
+for variant in $VARIANTS; do
+    case "$variant" in
+    cpu)
+        docker buildx imagetools create \
+            -t "${PREFIX}/deepracer-simapp:${VERSION}-cpu" \
+            "${PREFIX}/deepracer-simapp:${VERSION}-cpu-amd64" \
+            "${PREFIX}/deepracer-simapp:${VERSION}-cpu-arm64"
+        docker buildx imagetools inspect "${PREFIX}/deepracer-simapp:${VERSION}-cpu"
+        ;;
+    gpu)
+        docker buildx imagetools create \
+            -t "${PREFIX}/deepracer-simapp:${VERSION}-gpu" \
+            "${PREFIX}/deepracer-simapp:${VERSION}-gpu-amd64"
+        docker buildx imagetools inspect "${PREFIX}/deepracer-simapp:${VERSION}-gpu"
+        ;;
+    *)
+        echo "Unknown variant ${variant}" >&2
+        exit 1
+        ;;
+    esac
+done

--- a/push.sh
+++ b/push.sh
@@ -6,13 +6,16 @@ function ctrl_c() {
     exit 1
 }
 
+set -euo pipefail
+
 PREFIX="local"
-VERSION=$(jq -r '.simapp' VERSION)
+VARIANTS="cpu gpu"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 while getopts ":a:p:" opt; do
     case $opt in
     a)
-        ARCH="$OPTARG"
+        VARIANTS="$OPTARG"
         ;;
     p)
         PREFIX="$OPTARG"
@@ -24,9 +27,5 @@ while getopts ":a:p:" opt; do
     esac
 done
 
-echo "Pushing docker images for [$ARCH]"
-
-for A in $ARCH; do
-    echo "Pushing $PREFIX/deepracer-simapp:$VERSION-$A"
-    docker push $PREFIX/deepracer-simapp:$VERSION-$A
-done
+echo "push.sh is deprecated; publishing transparent manifests for [$VARIANTS] instead."
+exec "$DIR/publish-manifests.sh" -a "$VARIANTS" -p "$PREFIX"


### PR DESCRIPTION
This pull request introduces significant improvements to the build scripts and Docker image handling for the project, with a focus on multi-architecture support, enhanced build flexibility, and manifest publishing. The main changes include refactoring the build scripts to support both amd64 and arm64 architectures, adding options for more granular control over builds and pushes, and introducing a new script for publishing multi-architecture Docker manifests. These updates modernize the build pipeline and simplify the process of managing and distributing images.

**Build script and multi-architecture improvements:**

* Refactored `build.sh` to support building for multiple architectures (`amd64`, `arm64`) and variants (`cpu`, `gpu`), added `--platform` and `--push` options, and improved argument parsing and error handling. The script now tags images with both variant and architecture, and supports pushing images directly.
* Updated `build-droa.sh` to allow selective building and pushing of SimApp and validator images, added support for architecture-specific builds via `SIMAPP_ARCH`, and improved argument parsing with long options. [[1]](diffhunk://#diff-d2f8123c254131354885fe0d0f24693fdac234689bb8433f741e14d2bdd54162L9-R67) [[2]](diffhunk://#diff-d2f8123c254131354885fe0d0f24693fdac234689bb8433f741e14d2bdd54162L45-R128)

**Dockerfile and image tag changes:**

* Modified `docker/Dockerfile.build-bundle` and `docker/Dockerfile.combined` to accept architecture-specific tags via `CORE_TAG` and `BUNDLE_TAG`, enabling correct multi-architecture image builds. [[1]](diffhunk://#diff-d91a9c0a2c322ddbd0f4bd179396f2554a90648b0b5a3909f7d7559a79e11684L2-R3) [[2]](diffhunk://#diff-f9cc42b07e7ce0e146eb9be08583b935db4d8db897c85e0716e0f217983d4b62R2-R5)

**Manifest publishing and deprecation:**

* Added a new `publish-manifests.sh` script to publish multi-architecture Docker image manifests for each variant, replacing the old push mechanism.
* Deprecated `push.sh` in favor of `publish-manifests.sh`, updating it to simply invoke the new script. [[1]](diffhunk://#diff-770c3e9913b14393349d8b49bf91cb1f103b112ce1be180e65af958378776b38R9-R18) [[2]](diffhunk://#diff-770c3e9913b14393349d8b49bf91cb1f103b112ce1be180e65af958378776b38L27-R31)

**CI/CD pipeline enhancements:**

* Updated `buildspec.yml` to use the new build and manifest scripts, added ECR authentication, enabled platform-specific builds, and improved build target handling for CI/CD.