### PR TITLE
Upstream V1.1.1 + V1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Installed core technologies are:
  - Python 3.12
  - Tensorflow 2.20
  - CUDA 12.6 (GPU only)
- - Redis 8.6.1
+ - Redis 8.6.3
  - ROS 2 Jazzy
  - Gazebo Harmonic
 

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 {
     "simapp" : "6.0.4",
-    "deepracer-on-aws" : "v1.1.1"
+    "deepracer-on-aws" : "v1.1.2"
 }

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 {
     "simapp" : "6.0.4",
-    "deepracer-on-aws" : "v1.1.0"
+    "deepracer-on-aws" : "v1.1.1"
 }

--- a/docker/Dockerfile.build-core
+++ b/docker/Dockerfile.build-core
@@ -66,9 +66,9 @@ RUN git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git && \
 
 # Install Redis.
 RUN cd /tmp && \
-    wget https://download.redis.io/releases/redis-8.6.1.tar.gz && \
-    tar xvzf redis-8.6.1.tar.gz && \
-    cd redis-8.6.1 && \
+    wget https://download.redis.io/releases/redis-8.6.3.tar.gz && \
+    tar xvzf redis-8.6.3.tar.gz && \
+    cd redis-8.6.3 && \
     make && \
     make install && \
     rm -rf /tmp/redis*

--- a/docker/Dockerfile.upstream
+++ b/docker/Dockerfile.upstream
@@ -1,8 +1,8 @@
-# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.1
-# Image ID: ca389bc1801d
+# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.2
+# Image ID: d55358f19501
 # Base: Ubuntu 24.04 (Noble)
-# Built: May 11, 2026
-# Optimized: May 12, 2026
+# Built: May 13, 2026
+# Optimized: May 13, 2026
 
 FROM ubuntu:24.04
 

--- a/docker/Dockerfile.upstream
+++ b/docker/Dockerfile.upstream
@@ -1,8 +1,8 @@
-# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.0
-# Image ID: 5903cceba02c
+# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.1
+# Image ID: ca389bc1801d
 # Base: Ubuntu 24.04 (Noble)
-# Built: April 21, 2026
-# Optimized: April 22, 2026
+# Built: May 11, 2026
+# Optimized: May 12, 2026
 
 FROM ubuntu:24.04
 
@@ -167,15 +167,15 @@ RUN git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git && \
     ldconfig && \
     cd ../.. && rm -rf aws-sdk-cpp
 
-# Build and install Redis 8.6.1
+# Build and install Redis 8.6.3
 RUN cd /tmp && \
-    wget https://download.redis.io/releases/redis-8.6.1.tar.gz && \
-    tar xvzf redis-8.6.1.tar.gz && \
-    cd redis-8.6.1 && \
+    wget https://download.redis.io/releases/redis-8.6.3.tar.gz && \
+    tar xvzf redis-8.6.3.tar.gz && \
+    cd redis-8.6.3 && \
     make && \
     make install && \
     cd /tmp && \
-    rm -rf redis-8.6.1 redis-8.6.1.tar.gz
+    rm -rf redis-8.6.3 redis-8.6.3.tar.gz
 
 # Install Python dependencies
 RUN python3 -m pip install --no-cache-dir --ignore-installed \

--- a/docker/Dockerfile.upstream-adjusted
+++ b/docker/Dockerfile.upstream-adjusted
@@ -1,8 +1,8 @@
-# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.1
-# Image ID: ca389bc1801d
+# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.2
+# Image ID: d55358f19501
 # Base: Ubuntu 24.04 (Noble)
-# Built: May 11, 2026
-# Optimized: May 12, 2026
+# Built: May 13, 2026
+# Optimized: May 13, 2026
 
 FROM ubuntu:24.04
 

--- a/docker/Dockerfile.upstream-adjusted
+++ b/docker/Dockerfile.upstream-adjusted
@@ -1,8 +1,8 @@
-# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.0
-# Image ID: 5903cceba02c
+# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.1
+# Image ID: ca389bc1801d
 # Base: Ubuntu 24.04 (Noble)
-# Built: April 21, 2026
-# Optimized: April 22, 2026
+# Built: May 11, 2026
+# Optimized: May 12, 2026
 
 FROM ubuntu:24.04
 
@@ -149,15 +149,15 @@ RUN git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git && \
     ldconfig && \
     cd ../.. && rm -rf aws-sdk-cpp
 
-# Build and install Redis 8.6.1
+# Build and install Redis 8.6.3
 RUN cd /tmp && \
-    wget https://download.redis.io/releases/redis-8.6.1.tar.gz && \
-    tar xvzf redis-8.6.1.tar.gz && \
-    cd redis-8.6.1 && \
+    wget https://download.redis.io/releases/redis-8.6.3.tar.gz && \
+    tar xvzf redis-8.6.3.tar.gz && \
+    cd redis-8.6.3 && \
     make && \
     make install && \
     cd /tmp && \
-    rm -rf redis-8.6.1 redis-8.6.1.tar.gz
+    rm -rf redis-8.6.3 redis-8.6.3.tar.gz
 
 # Install Python dependencies
 RUN python3 -m pip install --no-cache-dir --ignore-installed \


### PR DESCRIPTION
No visible change, as it only included the upstream source to match code already in deepracer-simapp.

Redis upgraded to 8.6.3.