### PR TITLE
Upstream V1.1.3

### DIFF
--- a/.github/skills/deepracer-dockerfile-update/SKILL.md
+++ b/.github/skills/deepracer-dockerfile-update/SKILL.md
@@ -119,3 +119,4 @@ docker build --no-cache --dry-run -f docker/Dockerfile.upstream . 2>&1 | head -2
 | v1.0.11 | Bumped `conda-forge::curl==8.19.0`, `conda-forge::libcurl==8.19.0` |
 | v1.0.12 | Baseline (from v1.0.11 base) |
 | v1.0.13 | Base Ubuntu layer refresh only; `LABEL org.opencontainers.image.ref.name=ubuntu` removed; no package changes |
+| v1.1.3 | Base Ubuntu layer refresh; `urllib3==2.7.0`; `conda-forge::curl==8.20.0`, `conda-forge::libcurl==8.20.0`; added `nginx==1.31.1` to conda install; removed `19-aws-sdk.list` from rosdep init |

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 {
     "simapp" : "6.0.4",
-    "deepracer-on-aws" : "v1.1.2"
+    "deepracer-on-aws" : "v1.1.3"
 }

--- a/bundle/configs/environment.yml
+++ b/bundle/configs/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - zip
   - wget
   - pyqt=5
-  - curl==8.19.0
+  - curl==8.20.0
   - pip:
       - pygame==2.6.1
       - shapely==2.0.2
@@ -43,7 +43,7 @@ dependencies:
       - protobuf==6.33.5
       - pyparsing==3.2.5
       - requests==2.32.5
-      - urllib3==2.6.3
+      - urllib3==2.7.0
       - docutils==0.21.2
       - rospkg==1.6.0
       - tokenize-rt==6.2.0

--- a/docker/Dockerfile.upstream
+++ b/docker/Dockerfile.upstream
@@ -1,8 +1,8 @@
-# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.2
-# Image ID: d55358f19501
+# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.3
+# Image ID: ceb406201c10
 # Base: Ubuntu 24.04 (Noble)
-# Built: May 13, 2026
-# Optimized: May 13, 2026
+# Built: May 27, 2026
+# Optimized: May 28, 2026
 
 FROM ubuntu:24.04
 
@@ -187,7 +187,7 @@ RUN python3 -m pip install --no-cache-dir --ignore-installed \
     pillow==12.2.0 \
     pyyaml==6.0.3 \
     requests==2.32.5 \
-    urllib3==2.6.3 \
+    urllib3==2.7.0 \
     empy==4.2 \
     boto3==1.38.38 \
     bokeh==3.7.3 \
@@ -242,7 +242,6 @@ RUN pip3 install --no-cache-dir --use-pep517 annoy==1.17.3 && \
 
 # Initialize rosdep and add custom rosdep sources
 RUN rosdep init && \
-    sh -c 'echo "yaml https://s3-us-west-2.amazonaws.com/rosdep/base.yaml" > /etc/ros/rosdep/sources.list.d/19-aws-sdk.list' && \
     sh -c 'echo "yaml https://deepracer-managed-resources-us-east-1.s3.amazonaws.com/rosdep/python.yaml" > /etc/ros/rosdep/sources.list.d/18-deepracer.list' && \
     rosdep update --include-eol-distros
 
@@ -282,10 +281,11 @@ RUN conda env create -f /opt/amazon/configs/environment.yml && \
 # Install security updates via conda
 RUN /root/anaconda/bin/conda install -y \
     brotli-python==1.2.0 \
-    conda-forge::curl==8.19.0 \
-    conda-forge::libcurl==8.19.0 \
-    urllib3==2.6.3 \
+    conda-forge::curl==8.20.0 \
+    conda-forge::libcurl==8.20.0 \
+    urllib3==2.7.0 \
     requests==2.32.5 \
+    nginx==1.31.1 \
     && /root/anaconda/bin/conda clean -afy \
     && rm -rf /root/anaconda/lib/python3.12/site-packages/cryptography-42.0.5.dist-info
 

--- a/docker/Dockerfile.upstream-adjusted
+++ b/docker/Dockerfile.upstream-adjusted
@@ -1,8 +1,8 @@
-# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.2
-# Image ID: d55358f19501
+# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.3
+# Image ID: ceb406201c10
 # Base: Ubuntu 24.04 (Noble)
-# Built: May 13, 2026
-# Optimized: May 13, 2026
+# Built: May 27, 2026
+# Optimized: May 28, 2026
 
 FROM ubuntu:24.04
 
@@ -169,7 +169,7 @@ RUN python3 -m pip install --no-cache-dir --ignore-installed \
     pillow==12.2.0 \
     pyyaml==6.0.3 \
     requests==2.32.5 \
-    urllib3==2.6.3 \
+    urllib3==2.7.0 \
     empy==4.2 \
     boto3==1.38.38 \
     bokeh==3.7.3 \
@@ -225,7 +225,6 @@ RUN pip3 install --no-cache-dir --use-pep517 annoy==1.17.3 && \
 
 # Initialize rosdep and add custom rosdep sources
 RUN rosdep init && \
-    sh -c 'echo "yaml https://s3-us-west-2.amazonaws.com/rosdep/base.yaml" > /etc/ros/rosdep/sources.list.d/19-aws-sdk.list' && \
     sh -c 'echo "yaml https://deepracer-managed-resources-us-east-1.s3.amazonaws.com/rosdep/python.yaml" > /etc/ros/rosdep/sources.list.d/18-deepracer.list' && \
     rosdep update --include-eol-distros
 
@@ -266,10 +265,11 @@ RUN conda env create -f /opt/amazon/configs/environment.yml && \
 # Install security updates via conda
 RUN /root/anaconda/bin/conda install -y \
     brotli-python==1.2.0 \
-    conda-forge::curl==8.19.0 \
-    conda-forge::libcurl==8.19.0 \
-    urllib3==2.6.3 \
+    conda-forge::curl==8.20.0 \
+    conda-forge::libcurl==8.20.0 \
+    urllib3==2.7.0 \
     requests==2.32.5 \
+    nginx==1.31.1 \
     && /root/anaconda/bin/conda clean -afy \
     && rm -rf /root/anaconda/lib/python3.12/site-packages/cryptography-42.0.5.dist-info
 


### PR DESCRIPTION
This pull request updates the DeepRacer Docker image and related configuration to refresh the Ubuntu base layer, update several dependencies, add new packages, and remove an obsolete ROS dependency source. These changes improve security, add new functionality, and streamline the build setup.

**Dependency and Package Updates:**

- Upgraded `curl` and `libcurl` to version 8.20.0 from conda-forge in both the conda environment and Dockerfiles. [[1]](diffhunk://#diff-f4e893a56e542ace4f6bfbcb0d82887ebd1e7273ebb12d667c97d876cf9b3dc7L15-R15) [[2]](diffhunk://#diff-53aadc494fb1ec7dfb736c8f3849231df465864309e51d3f0565505524f3f5e3L285-R288) [[3]](diffhunk://#diff-e8926fb9f14391cc69dc37abd52ec639de709e688b0e64b18a733231c81bd219L269-R272) [[4]](diffhunk://#diff-3532e63c8b7f5321bf0b6a46d9f3194ff1040c2556882546b6d7f5b27b85a419R122)
- Updated `urllib3` to version 2.7.0 and `requests` to 2.32.5 throughout the environment and Dockerfiles. [[1]](diffhunk://#diff-f4e893a56e542ace4f6bfbcb0d82887ebd1e7273ebb12d667c97d876cf9b3dc7L46-R46) [[2]](diffhunk://#diff-53aadc494fb1ec7dfb736c8f3849231df465864309e51d3f0565505524f3f5e3L190-R190) [[3]](diffhunk://#diff-53aadc494fb1ec7dfb736c8f3849231df465864309e51d3f0565505524f3f5e3L285-R288) [[4]](diffhunk://#diff-e8926fb9f14391cc69dc37abd52ec639de709e688b0e64b18a733231c81bd219L172-R172) [[5]](diffhunk://#diff-e8926fb9f14391cc69dc37abd52ec639de709e688b0e64b18a733231c81bd219L269-R272) [[6]](diffhunk://#diff-3532e63c8b7f5321bf0b6a46d9f3194ff1040c2556882546b6d7f5b27b85a419R122)
- Added `nginx==1.31.1` to the conda install step in the Dockerfiles for additional web server support. [[1]](diffhunk://#diff-53aadc494fb1ec7dfb736c8f3849231df465864309e51d3f0565505524f3f5e3L285-R288) [[2]](diffhunk://#diff-e8926fb9f14391cc69dc37abd52ec639de709e688b0e64b18a733231c81bd219L269-R272) [[3]](diffhunk://#diff-3532e63c8b7f5321bf0b6a46d9f3194ff1040c2556882546b6d7f5b27b85a419R122)

**Base Image and Build Metadata:**

- Refreshed the base Ubuntu layer to the latest available and updated Dockerfile metadata to version `v1.1.3`. [[1]](diffhunk://#diff-53aadc494fb1ec7dfb736c8f3849231df465864309e51d3f0565505524f3f5e3L1-R5) [[2]](diffhunk://#diff-e8926fb9f14391cc69dc37abd52ec639de709e688b0e64b18a733231c81bd219L1-R5) [[3]](diffhunk://#diff-7b60b8e351cbb80c47459ffe2c79f1a26404871f49294780fe47ad0e58c09350L3-R3) [[4]](diffhunk://#diff-3532e63c8b7f5321bf0b6a46d9f3194ff1040c2556882546b6d7f5b27b85a419R122)

**ROS Dependency Source Cleanup:**

- Removed the addition of the obsolete `19-aws-sdk.list` source from the rosdep initialization step in the Dockerfiles. [[1]](diffhunk://#diff-53aadc494fb1ec7dfb736c8f3849231df465864309e51d3f0565505524f3f5e3L245) [[2]](diffhunk://#diff-e8926fb9f14391cc69dc37abd52ec639de709e688b0e64b18a733231c81bd219L228) [[3]](diffhunk://#diff-3532e63c8b7f5321bf0b6a46d9f3194ff1040c2556882546b6d7f5b27b85a419R122)