### PR TITLE
Alternative Docker Source

### DIFF
--- a/.github/skills/deepracer-dockerfile-update/SKILL.md
+++ b/.github/skills/deepracer-dockerfile-update/SKILL.md
@@ -121,3 +121,4 @@ docker build --no-cache --dry-run -f docker/Dockerfile.upstream . 2>&1 | head -2
 | v1.0.13 | Base Ubuntu layer refresh only; `LABEL org.opencontainers.image.ref.name=ubuntu` removed; no package changes |
 | v1.1.3 | Base Ubuntu layer refresh; `urllib3==2.7.0`; `conda-forge::curl==8.20.0`, `conda-forge::libcurl==8.20.0`; added `nginx==1.31.1` to conda install; removed `19-aws-sdk.list` from rosdep init |
 | v1.1.4 | Base layer rebuild only; no package changes |
+| v1.1.7 | Base layer rebuild only; no package changes (layer history identical to v1.1.4) |

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 {
     "simapp" : "6.0.4",
-    "deepracer-on-aws" : "v1.1.4"
+    "deepracer-on-aws" : "v1.1.7"
 }

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 PREFIX="awsdeepracercommunity"
 VARIANTS="cpu gpu"
 PLATFORM=""
+BASE_IMAGE="${BASE_IMAGE:-ubuntu:24.04}"
 
 function usage() {
     cat <<EOF
@@ -18,6 +19,9 @@ Usage: $0 [-a "cpu gpu"] [--platform linux/amd64|linux/arm64] [-p prefix] [-f] [
   -a, --variant       Space-separated variants to build (default: "cpu gpu")
       --platform      Docker platform to build for (default: native host)
   -p, --prefix        Image prefix / repository namespace
+      --base-image    Ubuntu base image for the CPU/core build (default: ubuntu:24.04).
+                      Use to pull from a non-Docker Hub source, e.g.
+                      public.ecr.aws/ubuntu/ubuntu:24.04 or a pull-through cache.
   -f, --no-cache      Disable Docker build cache
   -c, --rebuild-core  Force rebuild of the core builder image
       --push          Push built leaf images after the build completes
@@ -51,6 +55,10 @@ while [[ $# -gt 0 ]]; do
         ;;
     -p|--prefix)
         PREFIX="$2"
+        shift 2
+        ;;
+    --base-image)
+        BASE_IMAGE="$2"
         shift 2
         ;;
     -f|--no-cache)
@@ -101,6 +109,7 @@ if [ "$(docker images -q ${PREFIX}/deepracer-simapp-build-core:${CORE_TAG} 2>/de
     echo "Preparing core builder image ${PREFIX}/deepracer-simapp-build-core:${CORE_TAG} for ${PLATFORM}..."
     docker buildx build ${OPT_NOCACHE:-} --load --platform "${PLATFORM}" \
         -t ${PREFIX}/deepracer-simapp-build-core:${CORE_TAG} \
+        --build-arg BASE_IMAGE="${BASE_IMAGE}" \
         -f docker/Dockerfile.build-core .
 else
     echo "Core builder image ${PREFIX}/deepracer-simapp-build-core:${CORE_TAG} already exists."
@@ -126,7 +135,7 @@ for variant in $VARIANTS; do
         NVCC_VER="cuda-nvcc-12-6"
         ;;
     cpu)
-        CORE_IMG="ubuntu:24.04"
+        CORE_IMG="${BASE_IMAGE}"
         NVCC_VER=""
         ;;
     *)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,6 +15,10 @@ version: 0.2
 #   ARM64_BUILD_VARIANTS="cpu"    (default: "cpu")
 #   LOCAL_IMAGE_PREFIX            – local tag prefix when not pushing to Docker Hub
 #   PUBLIC_ECR_LOGIN_REGION       – region for public ECR auth token (default: us-east-1)
+#   BASE_IMAGE                    – Ubuntu base image for the CPU/core build. Set to a
+#                                  non-Docker Hub source to avoid Docker Hub rate limits,
+#                                  e.g. public.ecr.aws/ubuntu/ubuntu:24.04 or a pull-through
+#                                  cache repo. Defaults to ubuntu:24.04 (Docker Hub).
 phases:
   pre_build:
     commands:
@@ -72,9 +76,9 @@ phases:
             # Only push via build.sh when targeting Docker Hub; for ECR flows
             # build.sh builds locally and build-droa.sh handles the push.
             if [ "${ENABLE_IMAGE_PUSH}" = "true" ] && [ -n "${DOCKER_HUB_REGISTRY:-}" ]; then
-              bash build.sh --platform linux/amd64 -a "${BUILD_VARIANTS}" -p "${BUILD_PREFIX}" --push ${NO_CACHE:+--no-cache}
+              bash build.sh --platform linux/amd64 -a "${BUILD_VARIANTS}" -p "${BUILD_PREFIX}" ${BASE_IMAGE:+--base-image "${BASE_IMAGE}"} --push ${NO_CACHE:+--no-cache}
             else
-              bash build.sh --platform linux/amd64 -a "${BUILD_VARIANTS}" -p "${BUILD_PREFIX}" ${NO_CACHE:+--no-cache}
+              bash build.sh --platform linux/amd64 -a "${BUILD_VARIANTS}" -p "${BUILD_PREFIX}" ${BASE_IMAGE:+--base-image "${BASE_IMAGE}"} ${NO_CACHE:+--no-cache}
             fi
 
             if [ -n "${TARGET_REGISTRY}" ]; then
@@ -94,9 +98,9 @@ phases:
             fi
 
             if [ "${ENABLE_IMAGE_PUSH}" = "true" ] && [ -n "${DOCKER_HUB_REGISTRY:-}" ]; then
-              bash build.sh --platform linux/arm64 -a "${ARM64_BUILD_VARIANTS}" -p "${BUILD_PREFIX}" --push ${NO_CACHE:+--no-cache}
+              bash build.sh --platform linux/arm64 -a "${ARM64_BUILD_VARIANTS}" -p "${BUILD_PREFIX}" ${BASE_IMAGE:+--base-image "${BASE_IMAGE}"} --push ${NO_CACHE:+--no-cache}
             else
-              bash build.sh --platform linux/arm64 -a "${ARM64_BUILD_VARIANTS}" -p "${BUILD_PREFIX}" ${NO_CACHE:+--no-cache}
+              bash build.sh --platform linux/arm64 -a "${ARM64_BUILD_VARIANTS}" -p "${BUILD_PREFIX}" ${BASE_IMAGE:+--base-image "${BASE_IMAGE}"} ${NO_CACHE:+--no-cache}
             fi
             ;;
 

--- a/cloudformation/simapp-build-pipeline.yml
+++ b/cloudformation/simapp-build-pipeline.yml
@@ -88,11 +88,12 @@ Parameters:
 
   BaseImage:
     Type: String
-    Default: ubuntu:24.04
+    Default: public.ecr.aws/ubuntu/ubuntu:24.04
     Description: >-
-      Ubuntu base image used for the CPU/core simapp build. Override to pull from a
-      source other than Docker Hub and avoid the anonymous pull rate limit (HTTP 429),
-      e.g. public.ecr.aws/ubuntu/ubuntu:24.04 or an ECR pull-through cache repository.
+      Ubuntu base image used for the CPU/core simapp build. Defaults to the public ECR
+      mirror to avoid the Docker Hub anonymous pull rate limit (HTTP 429). Override to
+      pull from another source, e.g. ubuntu:24.04 on Docker Hub or an ECR pull-through
+      cache repository.
 
   BuildTimeoutMinutes:
     Type: Number

--- a/cloudformation/simapp-build-pipeline.yml
+++ b/cloudformation/simapp-build-pipeline.yml
@@ -86,6 +86,14 @@ Parameters:
     Default: aws/codebuild/amazonlinux2-aarch64-standard:3.0
     Description: Docker image for the arm64 CodeBuild environment.
 
+  BaseImage:
+    Type: String
+    Default: ubuntu:24.04
+    Description: >-
+      Ubuntu base image used for the CPU/core simapp build. Override to pull from a
+      source other than Docker Hub and avoid the anonymous pull rate limit (HTTP 429),
+      e.g. public.ecr.aws/ubuntu/ubuntu:24.04 or an ECR pull-through cache repository.
+
   BuildTimeoutMinutes:
     Type: Number
     Default: 120
@@ -301,6 +309,9 @@ Resources:
           - Name: DOCKER_HUB_KEY
             Type: SECRETS_MANAGER
             Value: !Sub '${DockerHubSecretArn}:${DockerHubSecretKey}'
+          - Name: BASE_IMAGE
+            Type: PLAINTEXT
+            Value: !Ref BaseImage
           - !If
             - EnableEcrPublishingCondition
             - Name: PRIVATE_ECR_REGISTRY
@@ -343,6 +354,9 @@ Resources:
           - Name: DOCKER_HUB_KEY
             Type: SECRETS_MANAGER
             Value: !Sub '${DockerHubSecretArn}:${DockerHubSecretKey}'
+          - Name: BASE_IMAGE
+            Type: PLAINTEXT
+            Value: !Ref BaseImage
 
   ManifestBuildProject:
     Type: AWS::CodeBuild::Project

--- a/cloudformation/simapp-public-ecr-pipeline.yml
+++ b/cloudformation/simapp-public-ecr-pipeline.yml
@@ -83,6 +83,14 @@ Parameters:
     Default: aws/codebuild/amazonlinux2-x86_64-standard:5.0
     Description: CodeBuild environment image for the AMD64 projects.
 
+  BaseImage:
+    Type: String
+    Default: ubuntu:24.04
+    Description: >-
+      Ubuntu base image used for the CPU/core simapp build. Override to pull from a
+      source other than Docker Hub and avoid the anonymous pull rate limit (HTTP 429),
+      e.g. public.ecr.aws/ubuntu/ubuntu:24.04 or an ECR pull-through cache repository.
+
   BuildTimeoutMinutes:
     Type: Number
     Default: 120
@@ -357,6 +365,9 @@ Resources:
           - Name: LOCAL_IMAGE_PREFIX
             Type: PLAINTEXT
             Value: !Ref LocalImagePrefix
+          - Name: BASE_IMAGE
+            Type: PLAINTEXT
+            Value: !Ref BaseImage
 
   # ── CodeBuild: validator images ───────────────────────────────────────────────
   ValidatorsBuildProject:

--- a/cloudformation/simapp-public-ecr-pipeline.yml
+++ b/cloudformation/simapp-public-ecr-pipeline.yml
@@ -85,11 +85,12 @@ Parameters:
 
   BaseImage:
     Type: String
-    Default: ubuntu:24.04
+    Default: public.ecr.aws/ubuntu/ubuntu:24.04
     Description: >-
-      Ubuntu base image used for the CPU/core simapp build. Override to pull from a
-      source other than Docker Hub and avoid the anonymous pull rate limit (HTTP 429),
-      e.g. public.ecr.aws/ubuntu/ubuntu:24.04 or an ECR pull-through cache repository.
+      Ubuntu base image used for the CPU/core simapp build. Defaults to the public ECR
+      mirror to avoid the Docker Hub anonymous pull rate limit (HTTP 429). Override to
+      pull from another source, e.g. ubuntu:24.04 on Docker Hub or an ECR pull-through
+      cache repository.
 
   BuildTimeoutMinutes:
     Type: Number

--- a/docker/Dockerfile.build-core
+++ b/docker/Dockerfile.build-core
@@ -1,4 +1,5 @@
-FROM ubuntu:24.04
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND="noninteractive" 
 ENV PYTHONWARNINGS="ignore::DeprecationWarning,ignore:::setuptools.command.install"

--- a/docker/Dockerfile.upstream
+++ b/docker/Dockerfile.upstream
@@ -1,8 +1,8 @@
-# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.4
-# Image ID: 1d1bb2c68911
+# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.7
+# Image ID: 8679c4e64965
 # Base: Ubuntu 24.04 (Noble)
-# Built: May 28, 2026
-# Optimized: May 31, 2026
+# Built: June 15, 2026
+# Optimized: June 16, 2026
 
 FROM ubuntu:24.04
 

--- a/docker/Dockerfile.upstream-adjusted
+++ b/docker/Dockerfile.upstream-adjusted
@@ -1,8 +1,8 @@
-# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.4
-# Image ID: 1d1bb2c68911
+# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.1.7
+# Image ID: 8679c4e64965
 # Base: Ubuntu 24.04 (Noble)
-# Built: May 28, 2026
-# Optimized: May 31, 2026
+# Built: June 15, 2026
+# Optimized: June 16, 2026
 
 FROM ubuntu:24.04
 


### PR DESCRIPTION
This pull request introduces support for customizing the Ubuntu base image used in the DeepRacer SimApp build process, making it easier to avoid Docker Hub rate limits by allowing alternative sources (such as public ECR or a pull-through cache). The change is implemented across the build scripts, Dockerfiles, CI/CD configuration, and CloudFormation templates. Additionally, the default base image is updated to use the public ECR Ubuntu mirror.

**Base Image Customization and Build Improvements:**

* Added a `--base-image` option to `build.sh` and updated the script to use the specified base image for CPU/core builds, defaulting to `ubuntu:24.04`. This allows overriding the base image source (e.g., to use public ECR instead of Docker Hub). (`build.sh`) [[1]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R14-R24) [[2]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R60-R63) [[3]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R112) [[4]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L129-R138)
* Modified `docker/Dockerfile.build-core` to accept a `BASE_IMAGE` build argument, enabling dynamic selection of the base image.
* Updated `buildspec.yml` to document and pass the `BASE_IMAGE` variable into the build process for both x86_64 and arm64 builds. [[1]](diffhunk://#diff-69387ac97f1b775f19989fc28150f89e785406cbff04643a969f5e396573dd5cR18-R21) [[2]](diffhunk://#diff-69387ac97f1b775f19989fc28150f89e785406cbff04643a969f5e396573dd5cL75-R81) [[3]](diffhunk://#diff-69387ac97f1b775f19989fc28150f89e785406cbff04643a969f5e396573dd5cL97-R103)

**CI/CD and Infrastructure Updates:**

* Enhanced CloudFormation templates (`simapp-build-pipeline.yml`, `simapp-public-ecr-pipeline.yml`) to accept a `BaseImage` parameter, defaulting to the public ECR Ubuntu 24.04 image, and propagate this value to CodeBuild environments. [[1]](diffhunk://#diff-0899a5da69ee5a2a2f0138411965be394d7c58855de8772b727339fc5f60c1c5R89-R97) [[2]](diffhunk://#diff-0899a5da69ee5a2a2f0138411965be394d7c58855de8772b727339fc5f60c1c5R313-R315) [[3]](diffhunk://#diff-0899a5da69ee5a2a2f0138411965be394d7c58855de8772b727339fc5f60c1c5R358-R360) [[4]](diffhunk://#diff-8494d760c5007549e7aed8e14cc9c52ac7c1786c5de943e7549225416cf63209R86-R94) [[5]](diffhunk://#diff-8494d760c5007549e7aed8e14cc9c52ac7c1786c5de943e7549225416cf63209R369-R371)
