### PR TITLE
Upstream v1.2.3

### DIFF
--- a/.github/skills/deepracer-dockerfile-update/SKILL.md
+++ b/.github/skills/deepracer-dockerfile-update/SKILL.md
@@ -127,3 +127,4 @@ docker build --no-cache --dry-run -f docker/Dockerfile.upstream . 2>&1 | head -2
 | v1.2.0 | Base layer rebuild only; no package changes (layer history identical to v1.1.7; base Ubuntu layer SHA unchanged) |
 | v1.2.1 | `cryptography==48.0.1` (was `46.0.7`); `nginx==1.31.2` (was `1.31.1`) |
 | v1.2.2 | Base layer rebuild only; no package changes (layer history identical to v1.2.1; built 2026-06-29) |
+| v1.2.3 | `conda-forge::curl==8.21.0`, `conda-forge::libcurl==8.21.0` (was `8.20.0`); built 2026-07-13 |

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 {
     "simapp" : "6.0.5",
-    "deepracer-on-aws" : "v1.2.2"
+    "deepracer-on-aws" : "v1.2.3"
 }

--- a/bundle/configs/environment.yml
+++ b/bundle/configs/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - zip
   - wget
   - pyqt=5
-  - curl==8.20.0
+  - curl==8.21.0
   - pip:
       - pygame==2.6.1
       - shapely==2.0.2

--- a/docker/Dockerfile.upstream
+++ b/docker/Dockerfile.upstream
@@ -1,8 +1,8 @@
-# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.2.2
-# Image ID: 810509598ace
+# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.2.3
+# Image ID: 2a92936c3298
 # Base: Ubuntu 24.04 (Noble)
-# Built: June 29, 2026
-# Optimized: July 02, 2026
+# Built: July 13, 2026
+# Optimized: July 14, 2026
 
 FROM ubuntu:24.04
 
@@ -281,8 +281,8 @@ RUN conda env create -f /opt/amazon/configs/environment.yml && \
 # Install security updates via conda
 RUN /root/anaconda/bin/conda install -y \
     brotli-python==1.2.0 \
-    conda-forge::curl==8.20.0 \
-    conda-forge::libcurl==8.20.0 \
+    conda-forge::curl==8.21.0 \
+    conda-forge::libcurl==8.21.0 \
     urllib3==2.7.0 \
     requests==2.32.5 \
     nginx==1.31.2 \

--- a/docker/Dockerfile.upstream-adjusted
+++ b/docker/Dockerfile.upstream-adjusted
@@ -1,8 +1,8 @@
-# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.2.2
-# Image ID: 810509598ace
+# Optimized Dockerfile for public.ecr.aws/aws-solutions/deepracer-on-aws-simapp:v1.2.3
+# Image ID: 2a92936c3298
 # Base: Ubuntu 24.04 (Noble)
-# Built: June 29, 2026
-# Optimized: July 02, 2026
+# Built: July 13, 2026
+# Optimized: July 14, 2026
 
 FROM ubuntu:24.04
 
@@ -265,8 +265,8 @@ RUN conda env create -f /opt/amazon/configs/environment.yml && \
 # Install security updates via conda
 RUN /root/anaconda/bin/conda install -y \
     brotli-python==1.2.0 \
-    conda-forge::curl==8.20.0 \
-    conda-forge::libcurl==8.20.0 \
+    conda-forge::curl==8.21.0 \
+    conda-forge::libcurl==8.21.0 \
     urllib3==2.7.0 \
     requests==2.32.5 \
     nginx==1.31.2 \

--- a/utils/extract-and-diff.sh
+++ b/utils/extract-and-diff.sh
@@ -46,5 +46,6 @@ rsync -a --delete ./ ~/deepracer-simapp/bundle/
 
 cd /tmp/bundle-src/ml/code
 rm -rf python3.12/
+rm -rf python3.10/
 rsync -a --delete ./ ~/deepracer-simapp/docker/files/ml-code/
 


### PR DESCRIPTION
This pull request updates the DeepRacer SimApp Docker image and related configuration to use the latest `curl` and `libcurl` versions from conda-forge, and bumps the application version to `v1.2.3`. It also updates build metadata and makes a minor adjustment to a utility script.

**Dependency updates:**

* Updated `curl` and `libcurl` to `8.21.0` from `8.20.0` in both `environment.yml` and the Dockerfiles (`docker/Dockerfile.upstream`, `docker/Dockerfile.upstream-adjusted`). [[1]](diffhunk://#diff-f4e893a56e542ace4f6bfbcb0d82887ebd1e7273ebb12d667c97d876cf9b3dc7L15-R15) [[2]](diffhunk://#diff-53aadc494fb1ec7dfb736c8f3849231df465864309e51d3f0565505524f3f5e3L284-R285) [[3]](diffhunk://#diff-e8926fb9f14391cc69dc37abd52ec639de709e688b0e64b18a733231c81bd219L268-R269)

**Version and metadata updates:**

* Bumped `deepracer-on-aws` version to `v1.2.3` in the `VERSION` file.
* Updated Dockerfile headers and build/optimization dates for the new version and image ID in both `docker/Dockerfile.upstream` and `docker/Dockerfile.upstream-adjusted`. [[1]](diffhunk://#diff-53aadc494fb1ec7dfb736c8f3849231df465864309e51d3f0565505524f3f5e3L1-R5) [[2]](diffhunk://#diff-e8926fb9f14391cc69dc37abd52ec639de709e688b0e64b18a733231c81bd219L1-R5)
* Added release note for `v1.2.3` in `.github/skills/deepracer-dockerfile-update/SKILL.md`.

**Utility script adjustment:**

* Modified `utils/extract-and-diff.sh` to also remove the `python3.10/` directory during the sync process.